### PR TITLE
chore(async): remove unnecessary `async` from `andThen` and `orElse`

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -301,7 +301,7 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
 
 	andThen<U, F>(fn: (value: T) => Result<U, F> | ResultAsync<U, F>): ResultAsync<U, E | F> {
 		return new ResultAsync(
-			this.promise.then(async (result) => {
+			this.promise.then((result) => {
 				if (result.isErr()) {
 					return err(result.error);
 				}
@@ -313,7 +313,7 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
 
 	orElse<F>(fn: (error: E) => Result<T, F> | ResultAsync<T, F>): ResultAsync<T, F> {
 		return new ResultAsync(
-			this.promise.then(async (result) => {
+			this.promise.then((result) => {
 				if (result.isOk()) {
 					return ok(result.value);
 				}


### PR DESCRIPTION
## Description

The promise callbacks for `andThen` and `orElse` functions in result-async.ts were unecessarily `async`. This PR removes the `async` keyword, requiring no other changes.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
