### PR TITLE
feat: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright © 2026 Jack Weilage
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,3 @@ Both `Result` and `ResultAsync` support:
 | `match({ ok, err })` | Pattern matches on the result |
 | `inspect(fn)` | Side effects on success value |
 | `inspectErr(fn)` | Side effects on error value |
-
-## License
-
-MIT


### PR DESCRIPTION
## Description

The library is MIT licensed, but doesn't have the raw text of the license.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
