### PR TITLE
chore: ensure renovate keeps biome schema up to date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended", "helpers:pinGitHubActionDigests"]
+	"extends": [
+		"config:recommended",
+		"helpers:pinGitHubActionDigests",
+		"customManagers:biomeVersions"
+	]
 }


### PR DESCRIPTION
## Description

Renovate has a [rule](https://docs.renovatebot.com/presets-customManagers/#custommanagersbiomeversions) for `biome.json` files to ensure their `$schema` is kept up to date. This PR enables it.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
