### PR TITLE
feat: added `expect` and `expectErr` methods

### DIFF
--- a/.changeset/rare-shrimps-sleep.md
+++ b/.changeset/rare-shrimps-sleep.md
@@ -1,0 +1,5 @@
+---
+"antithrow": minor
+---
+
+feat: added `expect` and `expectErr` methods for additional control over unwrapping

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Both `Result` and `ResultAsync` support:
 | `isErr()` | Type predicate for failure |
 | `unwrap()` | Returns value or throws |
 | `unwrapErr()` | Returns error or throws |
+| `expect(message)` | Returns value or throws with message |
+| `expectErr(message)` | Returns error or throws with message |
 | `unwrapOr(default)` | Returns value or default |
 | `unwrapOrElse(fn)` | Returns value or computes from error |
 | `map(fn)` | Transforms the success value |

--- a/examples/01-basic-usage.ts
+++ b/examples/01-basic-usage.ts
@@ -32,11 +32,17 @@ console.log(failure.isErr()); // true
 // Extract the success value with unwrap() (throws if Err!)
 console.log(success.unwrap()); // 5
 
+// If you want a custom panic message, use expect()
+console.log(success.expect("expected a value")); // 5
+
 // Safely extract with a fallback using unwrapOr()
 console.log(failure.unwrapOr(0)); // 0
 
 // Or compute a fallback from the error using unwrapOrElse()
 console.log(failure.unwrapOrElse((e) => e.length)); // 16
+
+// You can assert an Err using expectErr()
+console.log(failure.expectErr("expected an error")); // "Division by zero"
 
 // After isOk()/isErr() checks, TypeScript narrows the type,
 // giving you direct access to .value or .error

--- a/examples/07-async-basics.ts
+++ b/examples/07-async-basics.ts
@@ -37,7 +37,9 @@ async function main() {
 
 	// For quick extraction, you can await methods directly
 	console.log(await fetchUser(1).unwrap()); // { id: 1, name: "Alice" }
+	console.log(await fetchUser(1).expect("expected user")); // { id: 1, name: "Alice" }
 	console.log(await fetchUser(999).unwrapOr({ id: 0, name: "Guest" })); // { id: 0, name: "Guest" }
+	console.log(await fetchUser(999).expectErr("expected error")); // "User 999 not found"
 
 	// ResultAsync.try() wraps async functions that might throw, and awaiting it
 	// returns a `Result`.

--- a/src/result-async.test.ts
+++ b/src/result-async.test.ts
@@ -46,6 +46,30 @@ describe("ResultAsync", () => {
 		});
 	});
 
+	describe("expect", () => {
+		test("returns value for Ok", async () => {
+			const result = okAsync(42);
+			expect(await result.expect("should be ok")).toBe(42);
+		});
+
+		test("throws for Err with message", async () => {
+			const result = errAsync("error");
+			expect(result.expect("missing value")).rejects.toThrow("missing value");
+		});
+	});
+
+	describe("expectErr", () => {
+		test("returns error for Err", async () => {
+			const result = errAsync("error");
+			expect(await result.expectErr("should be error")).toBe("error");
+		});
+
+		test("throws for Ok with message", async () => {
+			const result = okAsync(42);
+			expect(result.expectErr("expected error")).rejects.toThrow("expected error");
+		});
+	});
+
 	describe("unwrapOr", () => {
 		test("returns value for Ok", async () => {
 			const result = okAsync(42);
@@ -498,6 +522,16 @@ describe("ResultAsync", () => {
 		test("unwrapErr returns Promise<E>", () => {
 			const result = errAsync("error");
 			expectTypeOf(result.unwrapErr()).toEqualTypeOf<Promise<string>>();
+		});
+
+		test("expect returns Promise<T>", () => {
+			const result = okAsync(42);
+			expectTypeOf(result.expect("expected")).toEqualTypeOf<Promise<number>>();
+		});
+
+		test("expectErr returns Promise<E>", () => {
+			const result = errAsync("error");
+			expectTypeOf(result.expectErr("expected")).toEqualTypeOf<Promise<string>>();
 		});
 
 		test("unwrapOr returns Promise<T>", () => {

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -54,6 +54,34 @@ interface ResultAsyncMethods<T, E> {
 	 */
 	unwrapErr(): Promise<E>;
 	/**
+	 * Returns the contained `Ok` value. Throws with the provided message if the result is `Err`.
+	 *
+	 * @example
+	 * ```ts
+	 * const value = await okAsync(42).expect("value should exist"); // 42
+	 * const error = await errAsync("oops").expect("value should exist"); // throws
+	 * ```
+	 *
+	 * @param message - The message to include in the thrown error if the result is `Err`.
+	 *
+	 * @returns A promise that resolves to the contained `Ok` value.
+	 */
+	expect(message: string): Promise<T>;
+	/**
+	 * Returns the contained `Err` value. Throws with the provided message if the result is `Ok`.
+	 *
+	 * @example
+	 * ```ts
+	 * const error = await errAsync("oops").expectErr("should be error"); // "oops"
+	 * const value = await okAsync(42).expectErr("should be error"); // throws
+	 * ```
+	 *
+	 * @param message - The message to include in the thrown error if the result is `Ok`.
+	 *
+	 * @returns A promise that resolves to the contained `Err` value.
+	 */
+	expectErr(message: string): Promise<E>;
+	/**
 	 * Returns the contained `Ok` value, or the provided default if `Err`.
 	 *
 	 * @example
@@ -342,6 +370,14 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
 
 	async unwrapErr(): Promise<E> {
 		return (await this.promise).unwrapErr();
+	}
+
+	async expect(message: string): Promise<T> {
+		return (await this.promise).expect(message);
+	}
+
+	async expectErr(message: string): Promise<E> {
+		return (await this.promise).expectErr(message);
 	}
 
 	async unwrapOr(defaultValue: T): Promise<T> {

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -45,6 +45,30 @@ describe("Result", () => {
 		});
 	});
 
+	describe("expect", () => {
+		test("returns value for Ok", () => {
+			const result = ok(42);
+			expect(result.expect("should be ok")).toBe(42);
+		});
+
+		test("throws for Err with message", () => {
+			const result = err("error");
+			expect(() => result.expect("missing value")).toThrow("missing value");
+		});
+	});
+
+	describe("expectErr", () => {
+		test("returns error for Err", () => {
+			const result = err("error");
+			expect(result.expectErr("should be error")).toBe("error");
+		});
+
+		test("throws for Ok with message", () => {
+			const result = ok(42);
+			expect(() => result.expectErr("expected error")).toThrow("expected error");
+		});
+	});
+
 	describe("unwrapOr", () => {
 		test("returns value for Ok", () => {
 			const result = ok(42);
@@ -429,6 +453,16 @@ describe("Result", () => {
 		test("unwrapErr returns E", () => {
 			const result = err("error");
 			expectTypeOf(result.unwrapErr()).toEqualTypeOf<string>();
+		});
+
+		test("expect returns T", () => {
+			const result = ok(42);
+			expectTypeOf(result.expect("expected")).toEqualTypeOf<number>();
+		});
+
+		test("expectErr returns E", () => {
+			const result = err("error");
+			expectTypeOf(result.expectErr("expected")).toEqualTypeOf<string>();
 		});
 
 		test("unwrapOr returns T", () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -51,6 +51,34 @@ interface ResultMethods<T, E> {
 	 */
 	unwrapErr(): E;
 	/**
+	 * Returns the contained `Ok` value. Throws with the provided message if the result is `Err`.
+	 *
+	 * @example
+	 * ```ts
+	 * const value = ok(42).expect("value should exist"); // 42
+	 * const error = err("oops").expect("value should exist"); // throws
+	 * ```
+	 *
+	 * @param message - The message to include in the thrown error if the result is `Err`.
+	 *
+	 * @returns The contained `Ok` value.
+	 */
+	expect(message: string): T;
+	/**
+	 * Returns the contained `Err` value. Throws with the provided message if the result is `Ok`.
+	 *
+	 * @example
+	 * ```ts
+	 * const error = err("oops").expectErr("should be error"); // "oops"
+	 * const value = ok(42).expectErr("should be error"); // throws
+	 * ```
+	 *
+	 * @param message - The message to include in the thrown error if the result is `Ok`.
+	 *
+	 * @returns The contained `Err` value.
+	 */
+	expectErr(message: string): E;
+	/**
 	 * Returns the contained `Ok` value, or the provided default if `Err`.
 	 *
 	 * @example
@@ -290,6 +318,14 @@ export class Ok<T, E> implements ResultMethods<T, E> {
 		throw new Error(`Called unwrapErr on an Ok value: ${String(this.value)}`);
 	}
 
+	expect(_message: string): T {
+		return this.value;
+	}
+
+	expectErr(message: string): E {
+		throw new Error(message);
+	}
+
 	unwrapOr(_defaultValue: T): T {
 		return this.value;
 	}
@@ -391,6 +427,14 @@ export class Err<T, E> implements ResultMethods<T, E> {
 	}
 
 	unwrapErr(): E {
+		return this.error;
+	}
+
+	expect(message: string): T {
+		throw new Error(message);
+	}
+
+	expectErr(_message: string): E {
 		return this.error;
 	}
 


### PR DESCRIPTION
## Description

The current implementation has no native way of throwing a custom error. This PR adds `expect` and `expectErr`, two functions which throw a provided error message.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [x] Tests added (if applicable)
- [x] Changeset added (if applicable)
