### PR TITLE
feat: allow `ok` and `okAsync` to accept a void success value

### DIFF
--- a/.changeset/dirty-cloths-cross.md
+++ b/.changeset/dirty-cloths-cross.md
@@ -1,0 +1,5 @@
+---
+"antithrow": minor
+---
+
+feat: allow `ok` and `okAsync` to accept a void success value

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ function validateEmail(email: string): Result<string, string> {
 function checkEmailAvailable(email: string): Result<void, string> {
   const taken = ["alice@example.com", "bob@example.com"];
   if (taken.includes(email)) return err("Email taken");
-  return ok(undefined);
+  return ok();
 }
 
 function saveUser(email: string, name: string): Result<User, string> {
@@ -189,9 +189,9 @@ const result = await chain(async function* () {
 
 | Function | Description |
 |----------|-------------|
-| `ok(value)` | Creates a successful result |
+| `ok(value?)` | Creates a successful result |
 | `err(error)` | Creates a failed result |
-| `okAsync(value)` | Creates an async successful result |
+| `okAsync(value?)` | Creates an async successful result |
 | `errAsync(error)` | Creates an async failed result |
 | `Result.try(fn)` | Wraps a throwing function in a Result |
 | `ResultAsync.try(fn)` | Wraps an async throwing function in a ResultAsync |

--- a/examples/01-basic-usage.ts
+++ b/examples/01-basic-usage.ts
@@ -32,6 +32,10 @@ console.log(failure.isErr()); // true
 // Extract the success value with unwrap() (throws if Err!)
 console.log(success.unwrap()); // 5
 
+// Ok with no arguments represents a void/empty success
+const empty = ok();
+console.log(empty.unwrap()); // undefined
+
 // If you want a custom panic message, use expect()
 console.log(success.expect("expected a value")); // 5
 

--- a/examples/07-async-basics.ts
+++ b/examples/07-async-basics.ts
@@ -41,6 +41,10 @@ async function main() {
 	console.log(await fetchUser(999).unwrapOr({ id: 0, name: "Guest" })); // { id: 0, name: "Guest" }
 	console.log(await fetchUser(999).expectErr("expected error")); // "User 999 not found"
 
+	// okAsync() also supports a void/empty success value
+	const empty = okAsync();
+	console.log(await empty.unwrap()); // undefined
+
 	// ResultAsync.try() wraps async functions that might throw, and awaiting it
 	// returns a `Result`.
 	const fetched = await ResultAsync.try(async () => {

--- a/src/result-async.test.ts
+++ b/src/result-async.test.ts
@@ -11,6 +11,13 @@ describe("ResultAsync", () => {
 			expect(await result.isErr()).toBe(false);
 			expect(await result.unwrap()).toBe(42);
 		});
+
+		test("creates an Ok value with no arguments", async () => {
+			const result = okAsync();
+			expect(await result.isOk()).toBe(true);
+			expect(await result.isErr()).toBe(false);
+			expect(await result.unwrap()).toBeUndefined();
+		});
 	});
 
 	describe("errAsync", () => {
@@ -481,6 +488,11 @@ describe("ResultAsync", () => {
 		test("okAsync returns ResultAsync<T, E>", () => {
 			const result = okAsync(42);
 			expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+		});
+
+		test("okAsync with no arguments returns ResultAsync<void, E>", () => {
+			const result = okAsync();
+			expectTypeOf(result).toEqualTypeOf<ResultAsync<void, never>>();
 		});
 
 		test("okAsync with explicit error type", () => {

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -487,6 +487,9 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
  * ```ts
  * const result = okAsync(42);
  * await result.unwrap(); // 42
+ *
+ * const empty = okAsync();
+ * await empty.unwrap(); // undefined
  * ```
  *
  * @template T - The type of the success value.
@@ -496,8 +499,10 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
  *
  * @returns A `ResultAsync` containing an `Ok` with the value.
  */
-export function okAsync<T, E = never>(value: T): ResultAsync<T, E> {
-	return ResultAsync.fromResult(ok(value));
+export function okAsync<E = never>(): ResultAsync<void, E>;
+export function okAsync<T, E = never>(value: T): ResultAsync<T, E>;
+export function okAsync<T, E = never>(value?: T): ResultAsync<T, E> {
+	return ResultAsync.fromResult(ok(value as T));
 }
 
 /**

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -10,6 +10,13 @@ describe("Result", () => {
 			expect(result.isErr()).toBe(false);
 			expect(result.value).toBe(42);
 		});
+
+		test("creates an Ok value with no arguments", () => {
+			const result = ok();
+			expect(result.isOk()).toBe(true);
+			expect(result.isErr()).toBe(false);
+			expect(result.value).toBeUndefined();
+		});
 	});
 
 	describe("err", () => {
@@ -407,6 +414,11 @@ describe("Result", () => {
 		test("ok returns Ok<T, E>", () => {
 			const result = ok(42);
 			expectTypeOf(result).toEqualTypeOf<Ok<number, never>>();
+		});
+
+		test("ok with no arguments returns Ok<void, E>", () => {
+			const result = ok();
+			expectTypeOf(result).toEqualTypeOf<Ok<void, never>>();
 		});
 
 		test("ok with explicit error type", () => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -518,6 +518,9 @@ export type Result<T, E> = Ok<T, E> | Err<T, E>;
  * ```ts
  * const result = ok(42);
  * result.unwrap(); // 42
+ *
+ * const empty = ok();
+ * empty.unwrap(); // undefined
  * ```
  *
  * @template T - The type of the success value.
@@ -527,8 +530,10 @@ export type Result<T, E> = Ok<T, E> | Err<T, E>;
  *
  * @returns An `Ok` result containing the value.
  */
-export function ok<T, E = never>(value: T): Ok<T, E> {
-	return new Ok(value);
+export function ok<E = never>(): Ok<void, E>;
+export function ok<T, E = never>(value: T): Ok<T, E>;
+export function ok<T, E = never>(value?: T): Ok<T, E> {
+	return new Ok(value as T);
 }
 
 /**


### PR DESCRIPTION
## Description

The `ok(undefined)` pattern is commonly used for a void success value. This PR allows the constructor to accept an optional parameter.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [x] Tests added (if applicable)
- [x] Changeset added (if applicable)
