### PR TITLE
chore(deps): pin bun to v1.3.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "2.3.13",
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
-        "@types/bun": "^1.3.6",
+        "@types/bun": "1.3.6",
         "lefthook": "^2.0.15",
         "publint": "^0.3.16",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
 		"@biomejs/biome": "2.3.13",
 		"@changesets/changelog-github": "^0.5.2",
 		"@changesets/cli": "^2.29.8",
-		"@types/bun": "^1.3.6",
+		"@types/bun": "1.3.6",
 		"lefthook": "^2.0.15",
 		"publint": "^0.3.16",
 		"typescript": "^5.9.3"
-	}
+	},
+	"packageManager": "bun@1.3.6"
 }


### PR DESCRIPTION
## Description

Minor version changes in `bun` often change behavior. This PR ensures that both editors and CI always use the same version of bun, synced via `package.json`.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
