### PR TITLE
fix: wrap rejected promises in `ResultAsync.fromPromise`

### DIFF
--- a/.changeset/jolly-sheep-float.md
+++ b/.changeset/jolly-sheep-float.md
@@ -1,0 +1,5 @@
+---
+"antithrow": patch
+---
+
+fix: wrap rejected promises in `ResultAsync.fromPromise`

--- a/src/result-async.test.ts
+++ b/src/result-async.test.ts
@@ -480,6 +480,13 @@ describe("ResultAsync", () => {
 			expect(await result.unwrapErr()).toBe("error");
 		});
 
+		test("wraps rejected Promise as Err", async () => {
+			const error = new Error("rejected");
+			const result = ResultAsync.fromPromise(Promise.reject(error));
+			expect(await result.isErr()).toBe(true);
+			expect(await result.unwrapErr()).toBe(error);
+		});
+
 		test("can be chained with map", async () => {
 			const promise = Promise.resolve(ok(21));
 			const result = ResultAsync.fromPromise(promise).map((x) => x * 2);

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -345,11 +345,10 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
 	 * @returns A `ResultAsync` containing either the resolved value or the caught error.
 	 */
 	static try<T, E = unknown>(fn: () => T | Promise<T>): ResultAsync<T, E> {
-		return new ResultAsync(
+		return ResultAsync.fromPromise(
 			Promise.resolve()
 				.then(fn)
-				.then((value) => ok<T, E>(value))
-				.catch((error) => err<T, E>(error)),
+				.then((value) => ok(value)),
 		);
 	}
 
@@ -375,7 +374,8 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
 	}
 
 	/**
-	 * Wraps an existing `Promise<Result<T, E>>` into a `ResultAsync`.
+	 * Wraps an existing `Promise<Result<T, E>>` into a `ResultAsync`. If the promise
+	 * rejects, the error is caught and wrapped in an `Err`.
 	 *
 	 * @example
 	 * ```ts
@@ -391,7 +391,7 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>>, ResultAsync
 	 * @returns A `ResultAsync` containing the resolved `Result`.
 	 */
 	static fromPromise<T, E>(promise: Promise<Result<T, E>>): ResultAsync<T, E> {
-		return new ResultAsync(promise);
+		return new ResultAsync(promise.catch((error) => err(error)));
 	}
 
 	// biome-ignore lint/suspicious/noThenProperty: We are implementing `PromiseLike`.


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [x] Tests added (if applicable)
- [x] Changeset added (if applicable)
