### PR TITLE
fix(eslint-plugin): recurse into all unary expressions except `void`

### DIFF
--- a/.changeset/fuzzy-goats-rule.md
+++ b/.changeset/fuzzy-goats-rule.md
@@ -1,0 +1,5 @@
+---
+"@antithrow/eslint-plugin": patch
+---
+
+flag all unary expressions except void

--- a/packages/eslint-plugin/src/rules/no-unused-result.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-result.test.ts
@@ -68,10 +68,6 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 			code: `${preamble}ok(1).match({ ok: (v) => v, err: (e) => 0 });`,
 		},
 		{
-			name: "non-void unary on Result (typeof)",
-			code: `${preamble}typeof ok(1);`,
-		},
-		{
 			name: "ternary with both branches voided",
 			code: `${preamble}declare const cond: boolean;\ncond ? void ok(1) : void ok(2);`,
 		},
@@ -163,6 +159,36 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		{
 			name: "nullish coalescing producing Result",
 			code: `${preamble}declare const cond: null | number;\ncond ?? ok(1);`,
+			errors: [{ messageId: "unusedResult" }],
+		},
+		{
+			name: "unary operator + on Result",
+			code: `${preamble}+ ok(1);`,
+			errors: [{ messageId: "unusedResult" }],
+		},
+		{
+			name: "unary operator - on Result",
+			code: `${preamble}- ok(1);`,
+			errors: [{ messageId: "unusedResult" }],
+		},
+		{
+			name: "unary operator ! on Result",
+			code: `${preamble}! ok(1);`,
+			errors: [{ messageId: "unusedResult" }],
+		},
+		{
+			name: "unary operator ~ on Result",
+			code: `${preamble}~ ok(1);`,
+			errors: [{ messageId: "unusedResult" }],
+		},
+		{
+			name: "unary operator typeof on Result",
+			code: `${preamble}typeof ok(1);`,
+			errors: [{ messageId: "unusedResult" }],
+		},
+		{
+			name: "unary operator delete on Result",
+			code: `${preamble}delete ok(1);`,
 			errors: [{ messageId: "unusedResult" }],
 		},
 	],

--- a/packages/eslint-plugin/src/rules/no-unused-result.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-result.ts
@@ -55,7 +55,8 @@ export const noUnusedResult = createRule({
 					if (node.operator === "void") {
 						return;
 					}
-					break;
+					checkExpression(node.argument);
+					return;
 
 				case "ConditionalExpression":
 					checkExpression(node.consequent);


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [x] Tests added (if applicable)
- [x] Changeset added (if applicable)
