### PR TITLE
chore: migrate repo from `jack-weilage/antithrow` to `antithrow/antithrow`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-	"changelog": ["@changesets/changelog-github", { "repo": "jack-weilage/antithrow" }],
+	"changelog": ["@changesets/changelog-github", { "repo": "antithrow/antithrow" }],
 	"commit": false,
 	"access": "public",
 	"baseBranch": "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     # Don't run on forks
-    if: github.repository == 'jack-weilage/antithrow'
+    if: github.repository == 'antithrow/antithrow'
     # TODO: Trusted publishing requires npm@11.5.1, but ubuntu-latest currently ships with
     # npm@10.8.2. ubuntu-slim is slightly newer, shipping with npm@11.6.2
     runs-on: ubuntu-slim

--- a/packages/antithrow/package.json
+++ b/packages/antithrow/package.json
@@ -6,7 +6,7 @@
 	"author": "Jack Weilage",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/jack-weilage/antithrow.git",
+		"url": "git+https://github.com/antithrow/antithrow.git",
 		"directory": "packages/antithrow"
 	},
 	"keywords": [

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 	<h1>@antithrow/eslint-plugin</h1>
 	<p>
-		ESLint rules for <a href="https://github.com/jack-weilage/antithrow">antithrow</a> Result types
+		ESLint rules for <a href="https://github.com/antithrow/antithrow">antithrow</a> Result types
 	</p>
 
 ![NPM Version](https://img.shields.io/npm/v/@antithrow/eslint-plugin)

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -6,7 +6,7 @@
 	"author": "Jack Weilage",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/jack-weilage/antithrow.git",
+		"url": "git+https://github.com/antithrow/antithrow.git",
 		"directory": "packages/eslint-plugin"
 	},
 	"keywords": [

--- a/packages/eslint-plugin/src/create-rule.ts
+++ b/packages/eslint-plugin/src/create-rule.ts
@@ -9,5 +9,5 @@ export interface AntithrowPluginDocs {
 
 export const createRule = ESLintUtils.RuleCreator<AntithrowPluginDocs>(
 	(name) =>
-		`https://github.com/jack-weilage/antithrow/blob/main/packages/eslint-plugin/docs/rules/${name}.md`,
+		`https://github.com/antithrow/antithrow/blob/main/packages/eslint-plugin/docs/rules/${name}.md`,
 );

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 	<h1>@antithrow/std</h1>
 	<p>
-		non-throwing wrappers around standard globals, powered by <a href="https://github.com/jack-weilage/antithrow">antithrow</a>
+		non-throwing wrappers around standard globals, powered by <a href="https://github.com/antithrow/antithrow">antithrow</a>
 	</p>
 
 ![NPM Version](https://img.shields.io/npm/v/@antithrow/std)

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -6,7 +6,7 @@
 	"author": "Jack Weilage",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/jack-weilage/antithrow.git",
+		"url": "git+https://github.com/antithrow/antithrow.git",
 		"directory": "packages/std"
 	},
 	"keywords": [


### PR DESCRIPTION
## Description

The repository was recently moved from my personal account to an org. This PR updates mentions of the `jack-weilage` account.

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] Linting passes (`bun run lint`)
- [ ] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
