### PR TITLE
chore: remove unused export

### DIFF
--- a/packages/antithrow/src/result-async.ts
+++ b/packages/antithrow/src/result-async.ts
@@ -5,7 +5,7 @@ import { err, ok } from "./result.js";
 /**
  * A type that can be either a value or a promise-like containing that value.
  */
-export type MaybePromise<T> = T | PromiseLike<T>;
+type MaybePromise<T> = T | PromiseLike<T>;
 
 interface ResultAsyncMethods<T, E> {
 	/**


### PR DESCRIPTION
## Description

A single export shouldn't be exported. It was annoying me, so I removed it.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
