### PR TITLE
ci: only add codecov comments on changes to coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,6 @@
+comment:
+  require_changes: true
+
 component_management:
   individual_components:
     - component_id: antithrow


### PR DESCRIPTION
## Description

The current codecov configuration always adds a comment, even when it just says that the coverage has stayed the same. This PR sets the configuration to only show a comment when a change to coverage (positive or negative) occurs.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
