### PR TITLE
test(node): improve happy/err path coverage

### DIFF
--- a/packages/node/src/fs/promises/copy-move.test.ts
+++ b/packages/node/src/fs/promises/copy-move.test.ts
@@ -74,4 +74,11 @@ describe("cp", () => {
 		const contents = await Bun.file(destPath).text();
 		expect(contents).toBe("cp content");
 	});
+
+	test("returns Err with ENOENT for missing source", async () => {
+		const result = await cp(join(tmpDir, "cp-missing.txt"), join(tmpDir, "cp-dest2.txt"));
+
+		expect(result.isErr()).toBe(true);
+		expect(result.unwrapErr().code).toBe("ENOENT");
+	});
 });

--- a/packages/node/src/fs/promises/dir.test.ts
+++ b/packages/node/src/fs/promises/dir.test.ts
@@ -117,6 +117,13 @@ describe("rm", () => {
 
 		expect(result.isOk()).toBe(true);
 	});
+
+	test("returns Err with ENOENT for missing path without force", async () => {
+		const result = await rm(join(tmpDir, "rm-missing-no-force"));
+
+		expect(result.isErr()).toBe(true);
+		expect(result.unwrapErr().code).toBe("ENOENT");
+	});
 });
 
 describe("mkdtemp", () => {
@@ -126,6 +133,13 @@ describe("mkdtemp", () => {
 		expect(result.isOk()).toBe(true);
 		const createdPath = result.unwrap();
 		expect(createdPath).toContain("mkdtemp-");
+	});
+
+	test("returns Err with ENOENT for invalid prefix path", async () => {
+		const result = await mkdtemp(join(tmpDir, "nonexistent-dir", "mkdtemp-"));
+
+		expect(result.isErr()).toBe(true);
+		expect(result.unwrapErr().code).toBe("ENOENT");
 	});
 });
 

--- a/packages/node/src/fs/promises/file.test.ts
+++ b/packages/node/src/fs/promises/file.test.ts
@@ -108,6 +108,15 @@ describe("appendFile", () => {
 		const contents = await Bun.file(filePath).text();
 		expect(contents).toBe("new content");
 	});
+
+	test("returns Err with ENOENT for missing parent directory", async () => {
+		const filePath = join(tmpDir, "no", "such", "dir", "append.txt");
+
+		const result = await appendFile(filePath, "data");
+
+		expect(result.isErr()).toBe(true);
+		expect(result.unwrapErr().code).toBe("ENOENT");
+	});
 });
 
 describe("truncate", () => {

--- a/packages/node/src/fs/promises/meta.test.ts
+++ b/packages/node/src/fs/promises/meta.test.ts
@@ -55,6 +55,13 @@ describe("lstat", () => {
 		const stats = result.unwrap();
 		expect(stats.isSymbolicLink()).toBe(true);
 	});
+
+	test("returns Err with ENOENT for missing path", async () => {
+		const result = await lstat(join(tmpDir, "lstat-missing.txt"));
+
+		expect(result.isErr()).toBe(true);
+		expect(result.unwrapErr().code).toBe("ENOENT");
+	});
 });
 
 describe("access", () => {
@@ -84,5 +91,12 @@ describe("statfs", () => {
 		const stats = result.unwrap();
 		expect(stats).toBeDefined();
 		expect(typeof stats.type).toBe("number");
+	});
+
+	test("returns Err with ENOENT for nonexistent path", async () => {
+		const result = await statfs(join(tmpDir, "statfs-missing"));
+
+		expect(result.isErr()).toBe(true);
+		expect(result.unwrapErr().code).toBe("ENOENT");
 	});
 });

--- a/packages/node/src/fs/promises/times.test.ts
+++ b/packages/node/src/fs/promises/times.test.ts
@@ -3,6 +3,7 @@ import {
 	mkdtemp as nodeMkdtemp,
 	rm as nodeRm,
 	stat as nodeStat,
+	symlink as nodeSymlink,
 	writeFile as nodeWriteFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -45,6 +46,20 @@ describe("utimes", () => {
 });
 
 describe("lutimes", () => {
+	test("returns Ok when setting times on a symlink", async () => {
+		const targetPath = join(tmpDir, "lutimes-target.txt");
+		const linkPath = join(tmpDir, "lutimes-link");
+		await nodeWriteFile(targetPath, "lutimes target");
+		await nodeSymlink(targetPath, linkPath);
+
+		const atime = new Date("2020-01-01T00:00:00Z");
+		const mtime = new Date("2021-06-15T12:00:00Z");
+
+		const result = await lutimes(linkPath, atime, mtime);
+
+		expect(result.isOk()).toBe(true);
+	});
+
 	test("returns Err with ENOENT for missing file", async () => {
 		const now = new Date();
 		const result = await lutimes(join(tmpDir, "lutimes-missing.txt"), now, now);


### PR DESCRIPTION
## Description

Testing of `@antithrow/node` misses happy or error paths for several functions. This PR completes the coverage.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [ ] Changeset added (if applicable)
