### PR TITLE
feat: modernize `@antithrow/std`

### DIFF
--- a/.changeset/tricky-poets-shake.md
+++ b/.changeset/tricky-poets-shake.md
@@ -1,0 +1,5 @@
+---
+"@antithrow/std": major
+---
+
+deps!: use modern `Result`/`Settled` APIs instead of `Result`/`ResultAsync`

--- a/apps/docs/docs/how-to/eslint-plugin/enforce-no-throwing-call.md
+++ b/apps/docs/docs/how-to/eslint-plugin/enforce-no-throwing-call.md
@@ -24,7 +24,7 @@ In a codebase already using antithrow, treat a fresh throwing call as a failure 
 | Was | Becomes |
 | --- | --- |
 | `fetch`, `atob`, `btoa`, `structuredClone`, `encodeURI`, `decodeURI`, `encodeURIComponent`, `decodeURIComponent`, `JSON.parse`, `JSON.stringify` | import from `@antithrow/std` |
-| `.json()`, `.text()`, `.arrayBuffer()`, `.blob()`, `.formData()` on a `Response` | `response.json(res)` / `response.text(res)` / … from `@antithrow/std` |
+| `.json()`, `.text()`, `.arrayBuffer()`, `.blob()`, `.formData()` on a `Response` | `Response.json(res)` / `Response.text(res)` / … from `@antithrow/std` |
 | `readFile`, `writeFile`, `mkdir`, … from `node:fs/promises` | import from `@antithrow/node/fs/promises` |
 
 ## Suppressing intentional usage

--- a/apps/docs/docs/how-to/std/fetch-json-safely.md
+++ b/apps/docs/docs/how-to/std/fetch-json-safely.md
@@ -5,22 +5,22 @@ description: Perform an HTTP request and decode the body without any throwing AP
 
 # Fetch JSON safely
 
-Use `@antithrow/std`'s `fetch` and `response.json()` so every network and parsing failure is a typed error.
+Use `@antithrow/std`'s `fetch` and `Response.json()` so every network and parsing failure is a typed error.
 
 ## The recipe
 
 ```ts
-import { fetch, response } from "@antithrow/std";
-import { Result } from "antithrow";
+import { Err, Result } from "antithrow";
+import { fetch, Response } from "@antithrow/std";
 
 const data = await Result.do(async function* () {
 	const res = yield* fetch("https://api.example.com/user");
 
 	if (!res.ok) {
-		return yield* Result.err({ kind: "http", status: res.status } as const);
+		yield* new Err({ kind: "http", status: res.status } as const);
 	}
 
-	const body = yield* response.json<User>(res);
+	const body = yield* Response.json<User>(res);
 	return body;
 });
 
@@ -29,12 +29,12 @@ if (data.isOk()) {
 }
 ```
 
-## Why both `fetch` and `response.json`
+## Why both `fetch` and `Response.json`
 
 The globals throw in two different places:
 
 - `fetch()` rejects on DNS, TLS, CORS, aborts.
-- `response.json()` throws `SyntaxError` on a non-JSON body (e.g. an HTML error page).
+- `Response.json()` throws `SyntaxError` on a non-JSON body (e.g. an HTML error page).
 
 `@antithrow/std` wraps both so neither can blow past your handler.
 
@@ -43,12 +43,12 @@ The globals throw in two different places:
 If you only need the happy path and a single error, chain instead:
 
 ```ts
-const data = await fetch("/api").andThen((res) => response.json<User>(res));
+const data = await fetch("/api").andThen((res) => Response.json<User>(res));
 ```
 
-The error type becomes the union of `fetch`'s and `response.json`'s — typically `TypeError | SyntaxError`.
+The error type becomes the union of `fetch`'s and `Response.json`'s — typically `TypeError | SyntaxError`.
 
 ## See also
 
-- Reference: [`fetch`](../../reference/std/fetch.md) · [`response`](../../reference/std/response.md)
+- Reference: [`fetch`](../../reference/std/fetch.md) · [`Response`](../../reference/std/response.md)
 - How-to: [Validate with Zod](../standard-schema/validate-with-zod.md)

--- a/apps/docs/docs/how-to/std/parse-json.md
+++ b/apps/docs/docs/how-to/std/parse-json.md
@@ -5,7 +5,7 @@ description: Use JSON.parse and JSON.stringify without catching SyntaxError by h
 
 # Parse and stringify JSON
 
-`@antithrow/std`'s `JSON` mirrors `globalThis.JSON` but returns `Result`. No `try/catch` needed.
+`@antithrow/std`'s `JSON` mirrors `globalThis.JSON` but returns `Settled`. No `try/catch` needed.
 
 ## Parse
 
@@ -29,7 +29,7 @@ The generic parameter is a type assertion — it does not validate. For validati
 const text = JSON.stringify({ id: 1 });
 ```
 
-`JSON.stringify` returns `Result<string | undefined, TypeError>` because `JSON.stringify` throws `TypeError` on circular references and on `BigInt`, and returns `undefined` for non-serializable top-level values like `undefined` or `Symbol`.
+`JSON.stringify` returns `Settled<string | undefined, TypeError>` because `JSON.stringify` throws `TypeError` on circular references and on `BigInt`, and returns `undefined` for non-serializable top-level values like `undefined` or `Symbol`.
 
 ## Parse + validate
 

--- a/apps/docs/docs/reference/std/base64.md
+++ b/apps/docs/docs/reference/std/base64.md
@@ -13,7 +13,7 @@ Non-throwing wrappers around `globalThis.atob` and `globalThis.btoa`.
 ## `atob(data)`
 
 ```ts
-function atob(data: string): Result<string, DOMException>;
+function atob(data: string): Settled<string, DOMException>;
 ```
 
 Decodes a base64-encoded ASCII string. Returns `Err(DOMException)` for invalid input.
@@ -21,7 +21,7 @@ Decodes a base64-encoded ASCII string. Returns `Err(DOMException)` for invalid i
 ## `btoa(data)`
 
 ```ts
-function btoa(data: string): Result<string, DOMException>;
+function btoa(data: string): Settled<string, DOMException>;
 ```
 
 Encodes a binary string as base64. Returns `Err(DOMException)` when `data` contains characters outside the Latin-1 range.

--- a/apps/docs/docs/reference/std/fetch.md
+++ b/apps/docs/docs/reference/std/fetch.md
@@ -16,7 +16,7 @@ Non-throwing wrapper around `globalThis.fetch`. Non-2xx responses are `Ok`; only
 function fetch(
 	input: string | URL | Request,
 	init?: RequestInit,
-): ResultAsync<Response, DOMException | TypeError>;
+): Result<Response, DOMException | TypeError>;
 ```
 
 | Argument | Type | Description |
@@ -26,7 +26,7 @@ function fetch(
 
 ## Returns
 
-`ResultAsync<Response, DOMException | TypeError>` — resolves to `Ok(response)` for any completed HTTP response (including 4xx and 5xx). Network failures, CORS rejections, and `AbortError`s become `Err`.
+`Result<Response, DOMException | TypeError>` — returns `Pending` until the request settles, then `Ok(response)` for any completed HTTP response (including 4xx and 5xx). Network failures, CORS rejections, and `AbortError`s become `Err`.
 
 ## Throws
 

--- a/apps/docs/docs/reference/std/json.md
+++ b/apps/docs/docs/reference/std/json.md
@@ -16,7 +16,7 @@ Non-throwing wrappers around `globalThis.JSON.parse` and `globalThis.JSON.string
 JSON.parse<T = unknown>(
 	text: string,
 	reviver?: (this: unknown, key: string, value: unknown) => unknown,
-): Result<T, SyntaxError>;
+): Settled<T, SyntaxError>;
 ```
 
 | Argument | Type | Description |
@@ -39,7 +39,7 @@ JSON.stringify(
 	value: unknown,
 	replacer?: JsonStringifyReplacer,
 	space?: string | number,
-): Result<string | undefined, TypeError>;
+): Settled<string | undefined, TypeError>;
 ```
 
 | Argument | Type | Description |

--- a/apps/docs/docs/reference/std/response.md
+++ b/apps/docs/docs/reference/std/response.md
@@ -8,14 +8,14 @@ sidebar_position: 3
 
 Package: `@antithrow/std`
 
-Non-throwing wrappers around `globalThis.Response` body-reading methods. Each accepts a `Response` and returns a `ResultAsync` that captures any rejection (invalid JSON, already-consumed body) as `Err`.
+Non-throwing wrappers around `globalThis.Response` body-reading methods. Each accepts a `Response` and returns a `Result` that captures any rejection (invalid JSON, already-consumed body) as `Err`.
 
 ## `Response.json(response)`
 
 ```ts
 Response.json<T = unknown>(
 	response: Response,
-): ResultAsync<T, DOMException | TypeError | SyntaxError>;
+): Result<T, DOMException | TypeError | SyntaxError>;
 ```
 
 ## `Response.text(response)`
@@ -23,7 +23,7 @@ Response.json<T = unknown>(
 ```ts
 Response.text(
 	response: Response,
-): ResultAsync<string, DOMException | TypeError>;
+): Result<string, DOMException | TypeError>;
 ```
 
 ## `Response.arrayBuffer(response)`
@@ -31,7 +31,7 @@ Response.text(
 ```ts
 Response.arrayBuffer(
 	response: Response,
-): ResultAsync<ArrayBuffer, DOMException | TypeError | RangeError>;
+): Result<ArrayBuffer, DOMException | TypeError | RangeError>;
 ```
 
 ## `Response.blob(response)`
@@ -39,7 +39,7 @@ Response.arrayBuffer(
 ```ts
 Response.blob(
 	response: Response,
-): ResultAsync<Blob, DOMException | TypeError>;
+): Result<Blob, DOMException | TypeError>;
 ```
 
 ## `Response.formData(response)`
@@ -47,7 +47,7 @@ Response.blob(
 ```ts
 Response.formData(
 	response: Response,
-): ResultAsync<FormData, DOMException | TypeError>;
+): Result<FormData, DOMException | TypeError>;
 ```
 
 ## Throws

--- a/apps/docs/docs/reference/std/structured-clone.md
+++ b/apps/docs/docs/reference/std/structured-clone.md
@@ -16,7 +16,7 @@ Non-throwing wrapper around `globalThis.structuredClone`.
 function structuredClone<T>(
 	value: T,
 	options?: StructuredSerializeOptions,
-): Result<T, DOMException>;
+): Settled<T, DOMException>;
 ```
 
 | Argument | Type | Description |

--- a/apps/docs/docs/reference/std/uri.md
+++ b/apps/docs/docs/reference/std/uri.md
@@ -13,13 +13,13 @@ Non-throwing wrappers around `globalThis.encodeURI`, `encodeURIComponent`, `deco
 ## `encodeURI(uri)`
 
 ```ts
-function encodeURI(uri: string): Result<string, URIError>;
+function encodeURI(uri: string): Settled<string, URIError>;
 ```
 
 ## `decodeURI(encodedURI)`
 
 ```ts
-function decodeURI(encodedURI: string): Result<string, URIError>;
+function decodeURI(encodedURI: string): Settled<string, URIError>;
 ```
 
 ## `encodeURIComponent(component)`
@@ -27,13 +27,13 @@ function decodeURI(encodedURI: string): Result<string, URIError>;
 ```ts
 function encodeURIComponent(
 	uriComponent: string | number | boolean,
-): Result<string, URIError>;
+): Settled<string, URIError>;
 ```
 
 ## `decodeURIComponent(encodedURIComponent)`
 
 ```ts
-function decodeURIComponent(encodedURIComponent: string): Result<string, URIError>;
+function decodeURIComponent(encodedURIComponent: string): Settled<string, URIError>;
 ```
 
 Each returns `Err(URIError)` for malformed input (for example, an orphaned `%` sequence).

--- a/apps/docs/docs/tutorial/01-setup.md
+++ b/apps/docs/docs/tutorial/01-setup.md
@@ -46,7 +46,7 @@ npm install antithrow @antithrow/std @antithrow/standard-schema zod
 ```
 
 - `antithrow` — the core `Ok`, `Err`, `Pending`, and `Result` types.
-- `@antithrow/std` — a non-throwing `fetch` that returns a `Result` instead of throwing.
+- `@antithrow/std` — non-throwing wrappers around standard globals like `fetch`.
 - `@antithrow/standard-schema` — wires any Standard Schema validator (like Zod) into a `Result`.
 - `zod` — the validator we will use in the final step.
 

--- a/apps/docs/docs/tutorial/04-go-async.md
+++ b/apps/docs/docs/tutorial/04-go-async.md
@@ -36,7 +36,7 @@ Three things are new:
 
 1. `fetch(url)` returns a result whose asynchronous branch is `Pending`. Because `Pending` is `PromiseLike`, the whole chain becomes `Pending` once a `.andThen` returns one.
 2. `Response.json(response)` reads the body and returns another `Pending`. It is safe to chain them because `andThen` threads errors through.
-3. `await` on a `Pending` hands back a settled `Ok` or `Err`, so `config` has the type `Result<unknown, …>` at the end.
+3. `await` on a `Pending` hands back a settled `Ok` or `Err`, so `config` has the type `Settled<unknown, …>` at the end.
 
 ## Inspect the outcome
 

--- a/apps/docs/docs/tutorial/05-validate-the-response.md
+++ b/apps/docs/docs/tutorial/05-validate-the-response.md
@@ -36,8 +36,8 @@ function parsePort(raw: string): Result<number, "invalid-port"> {
 	return new Ok(port);
 }
 
-async function loadConfig(rawPort: string): Promise<Result<Config, unknown>> {
-	return await parsePort(rawPort)
+function loadConfig(rawPort: string): Result<Config, unknown> {
+	return parsePort(rawPort)
 		.map((port) => `http://localhost:${port}/config.json`)
 		.andThen((url) => fetch(url))
 		.andThen((response) => Response.json(response))

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -110,29 +110,6 @@ btoa("hello");  // ok("aGVsbG8=")
 atob("!!!");    // err(DOMException)
 ```
 
-## API Reference
+## Reference
 
-### Sync (`Result`)
-
-| Export               | Signature                                                             | Error Type     |
-| -------------------- | --------------------------------------------------------------------- | -------------- |
-| `JSON.parse`         | `<T = unknown>(text, reviver?) → Result<T, SyntaxError>`              | `SyntaxError`  |
-| `JSON.stringify`     | `(value, replacer?, space?) → Result<string \| undefined, TypeError>` | `TypeError`    |
-| `structuredClone`    | `<T>(value, options?) → Result<T, DOMException>`                      | `DOMException` |
-| `decodeURI`          | `(encodedURI) → Result<string, URIError>`                             | `URIError`     |
-| `decodeURIComponent` | `(encodedURIComponent) → Result<string, URIError>`                    | `URIError`     |
-| `encodeURI`          | `(uri) → Result<string, URIError>`                                    | `URIError`     |
-| `encodeURIComponent` | `(uriComponent) → Result<string, URIError>`                           | `URIError`     |
-| `atob`               | `(data) → Result<string, DOMException>`                               | `DOMException` |
-| `btoa`               | `(data) → Result<string, DOMException>`                               | `DOMException` |
-
-### Async (`ResultAsync`)
-
-| Export                 | Signature                                                                       | Error Type                                 |
-| ---------------------- | ------------------------------------------------------------------------------- | ------------------------------------------ |
-| `fetch`                | `(input, init?) → ResultAsync<Response, DOMException \| TypeError>`             | `DOMException \| TypeError`                |
-| `Response.json`        | `<T = unknown>(res) → ResultAsync<T, DOMException \| TypeError \| SyntaxError>` | `DOMException \| TypeError \| SyntaxError` |
-| `Response.text`        | `(res) → ResultAsync<string, DOMException \| TypeError>`                        | `DOMException \| TypeError`                |
-| `Response.arrayBuffer` | `(res) → ResultAsync<ArrayBuffer, DOMException \| TypeError \| RangeError>`     | `DOMException \| TypeError \| RangeError`  |
-| `Response.blob`        | `(res) → ResultAsync<Blob, DOMException \| TypeError>`                          | `DOMException \| TypeError`                |
-| `Response.formData`    | `(res) → ResultAsync<FormData, DOMException \| TypeError>`                      | `DOMException \| TypeError`                |
+Full reference: <https://antithrow.dev/docs/reference/std>

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -12,8 +12,7 @@
 ## Why
 
 Standard APIs like `JSON.parse`, `fetch`, and `atob` communicate failure by throwing.
-`@antithrow/std` re-exports them as thin wrappers that return `Result` or `ResultAsync` instead,
-so error handling is type-safe and composable out of the box.
+`@antithrow/std` re-exports them as thin wrappers that return `Settled` or `Result`, so error handling stays type-safe and composable.
 
 ```ts
 import { JSON, fetch, Response } from "@antithrow/std";
@@ -41,7 +40,7 @@ rename the import:
 ```ts
 import { JSON as SafeJSON } from "@antithrow/std";
 
-SafeJSON.parse("...");  // Result<unknown, SyntaxError>
+SafeJSON.parse("...");  // Settled<unknown, SyntaxError>
 JSON.parse("...");      // throws on invalid input
 ```
 

--- a/packages/std/src/base64.ts
+++ b/packages/std/src/base64.ts
@@ -1,4 +1,5 @@
-import { Result } from "antithrow/legacy";
+import type { Settled } from "antithrow";
+import { Result } from "antithrow";
 
 /**
  * Non-throwing wrapper around `globalThis.atob(...)`.
@@ -11,9 +12,9 @@ import { Result } from "antithrow/legacy";
  *
  * @param data - The base64-encoded string to decode.
  *
- * @returns A `Result` containing the decoded string or the thrown error.
+ * @returns A `Settled` result containing the decoded string or the thrown error.
  */
-export function atob(data: string): Result<string, DOMException> {
+export function atob(data: string): Settled<string, DOMException> {
 	return Result.try(() => globalThis.atob(data));
 }
 
@@ -28,8 +29,8 @@ export function atob(data: string): Result<string, DOMException> {
  *
  * @param data - The string to encode as base64.
  *
- * @returns A `Result` containing the base64-encoded string or the thrown error.
+ * @returns A `Settled` result containing the base64-encoded string or the thrown error.
  */
-export function btoa(data: string): Result<string, DOMException> {
+export function btoa(data: string): Settled<string, DOMException> {
 	return Result.try(() => globalThis.btoa(data));
 }

--- a/packages/std/src/fetch.ts
+++ b/packages/std/src/fetch.ts
@@ -1,4 +1,4 @@
-import { ResultAsync } from "antithrow/legacy";
+import { Result } from "antithrow";
 
 /**
  * Non-throwing wrapper around `globalThis.fetch`.
@@ -12,11 +12,11 @@ import { ResultAsync } from "antithrow/legacy";
  * @param input - The resource to fetch.
  * @param init - Optional request configuration.
  *
- * @returns A `ResultAsync` containing the `Response`, or an error if the fetch rejects.
+ * @returns A `Result` containing the `Response`, or an error if the fetch rejects.
  */
 export function fetch(
 	input: string | URL | Request,
 	init?: RequestInit,
-): ResultAsync<Response, DOMException | TypeError> {
-	return ResultAsync.try(() => globalThis.fetch(input, init));
+): Result<Response, DOMException | TypeError> {
+	return Result.try(() => globalThis.fetch(input, init));
 }

--- a/packages/std/src/json.test.ts
+++ b/packages/std/src/json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, test } from "bun:test";
-import type { Ok } from "antithrow/legacy";
+import type { Ok } from "antithrow";
 // biome-ignore lint/suspicious/noShadowRestrictedNames: testing the wrapper
 import { JSON } from "./json.js";
 

--- a/packages/std/src/json.ts
+++ b/packages/std/src/json.ts
@@ -1,5 +1,5 @@
-import type { Ok } from "antithrow/legacy";
-import { Result } from "antithrow/legacy";
+import type { Ok, Settled } from "antithrow";
+import { Result } from "antithrow";
 
 type JsonStringifyReplacer =
 	| ((this: unknown, key: string, value: unknown) => unknown)
@@ -9,7 +9,7 @@ type JsonStringifyReplacer =
 type NonSerializableTopLevel = undefined | symbol | ((...args: unknown[]) => unknown);
 
 /**
- * Converts a value to a JSON string, returning a `Result` instead of throwing.
+ * Converts a value to a JSON string, returning a `Settled` result instead of throwing.
  *
  * @example
  * ```ts
@@ -26,7 +26,7 @@ type NonSerializableTopLevel = undefined | symbol | ((...args: unknown[]) => unk
  * @param replacer - An optional function or array that alters the stringification.
  * @param space - An optional string or number for indentation.
  *
- * @returns A `Result` containing the JSON string (or `undefined` for non-serializable top-level values) or the thrown error.
+ * @returns A `Settled` result containing the JSON string (or `undefined` for non-serializable top-level values) or the thrown error.
  */
 function stringify(
 	value: NonSerializableTopLevel,
@@ -37,12 +37,12 @@ function stringify(
 	value: unknown,
 	replacer?: JsonStringifyReplacer,
 	space?: string | number,
-): Result<string | undefined, TypeError>;
+): Settled<string | undefined, TypeError>;
 function stringify(
 	value: unknown,
 	replacer?: JsonStringifyReplacer,
 	space?: string | number,
-): Result<string | undefined, TypeError> {
+): Settled<string | undefined, TypeError> {
 	return Result.try(() =>
 		globalThis.JSON.stringify(value, replacer as (key: string, value: unknown) => unknown, space),
 	);
@@ -65,7 +65,7 @@ function stringify(
 // biome-ignore lint/suspicious/noShadowRestrictedNames: intentionally wrapping the global
 export const JSON = {
 	/**
-	 * Parses a JSON string, returning a `Result` instead of throwing.
+	 * Parses a JSON string, returning a `Settled` result instead of throwing.
 	 *
 	 * @example
 	 * ```ts
@@ -81,12 +81,12 @@ export const JSON = {
 	 * @param text - The JSON string to parse.
 	 * @param reviver - An optional function that transforms the results.
 	 *
-	 * @returns A `Result` containing the parsed value or the thrown error.
+	 * @returns A `Settled` result containing the parsed value or the thrown error.
 	 */
 	parse<T = unknown>(
 		text: string,
 		reviver?: (this: unknown, key: string, value: unknown) => unknown,
-	): Result<T, SyntaxError> {
+	): Settled<T, SyntaxError> {
 		return Result.try(() => globalThis.JSON.parse(text, reviver) as T);
 	},
 

--- a/packages/std/src/response.ts
+++ b/packages/std/src/response.ts
@@ -1,9 +1,9 @@
-import { ResultAsync } from "antithrow/legacy";
+import { Result } from "antithrow";
 
 /**
  * Non-throwing wrappers around `globalThis.Response` body-reading methods.
  *
- * Each method accepts a `Response` and returns a `ResultAsync` that captures
+ * Each method accepts a `Response` and returns a `Result` that captures
  * any rejection (e.g. invalid JSON, already-consumed body) as an `Err`.
  *
  * @example
@@ -22,10 +22,10 @@ export const Response = {
 	 *
 	 * @param response - The `Response` to read from.
 	 *
-	 * @returns A `ResultAsync` containing the parsed value, or an error if parsing fails.
+	 * @returns A `Result` containing the parsed value, or an error if parsing fails.
 	 */
-	json<T = unknown>(response: Response): ResultAsync<T, DOMException | TypeError | SyntaxError> {
-		return ResultAsync.try(() => response.json() as Promise<T>);
+	json<T = unknown>(response: Response): Result<T, DOMException | TypeError | SyntaxError> {
+		return Result.try(() => response.json() as Promise<T>);
 	},
 
 	/**
@@ -38,10 +38,10 @@ export const Response = {
 	 *
 	 * @param response - The `Response` to read from.
 	 *
-	 * @returns A `ResultAsync` containing the text content, or an error if reading fails.
+	 * @returns A `Result` containing the text content, or an error if reading fails.
 	 */
-	text(response: Response): ResultAsync<string, DOMException | TypeError> {
-		return ResultAsync.try(() => response.text());
+	text(response: Response): Result<string, DOMException | TypeError> {
+		return Result.try(() => response.text());
 	},
 
 	/**
@@ -54,10 +54,10 @@ export const Response = {
 	 *
 	 * @param response - The `Response` to read from.
 	 *
-	 * @returns A `ResultAsync` containing the `ArrayBuffer`, or an error if reading fails.
+	 * @returns A `Result` containing the `ArrayBuffer`, or an error if reading fails.
 	 */
-	arrayBuffer(response: Response): ResultAsync<ArrayBuffer, DOMException | TypeError | RangeError> {
-		return ResultAsync.try(() => response.arrayBuffer());
+	arrayBuffer(response: Response): Result<ArrayBuffer, DOMException | TypeError | RangeError> {
+		return Result.try(() => response.arrayBuffer());
 	},
 
 	/**
@@ -70,10 +70,10 @@ export const Response = {
 	 *
 	 * @param response - The `Response` to read from.
 	 *
-	 * @returns A `ResultAsync` containing the `Blob`, or an error if reading fails.
+	 * @returns A `Result` containing the `Blob`, or an error if reading fails.
 	 */
-	blob(response: Response): ResultAsync<Blob, DOMException | TypeError> {
-		return ResultAsync.try(() => response.blob());
+	blob(response: Response): Result<Blob, DOMException | TypeError> {
+		return Result.try(() => response.blob());
 	},
 
 	/**
@@ -86,9 +86,9 @@ export const Response = {
 	 *
 	 * @param response - The `Response` to read from.
 	 *
-	 * @returns A `ResultAsync` containing the `FormData`, or an error if reading fails.
+	 * @returns A `Result` containing the `FormData`, or an error if reading fails.
 	 */
-	formData(response: Response): ResultAsync<FormData, DOMException | TypeError> {
-		return ResultAsync.try(() => response.formData());
+	formData(response: Response): Result<FormData, DOMException | TypeError> {
+		return Result.try(() => response.formData());
 	},
 } as const;

--- a/packages/std/src/structured-clone.ts
+++ b/packages/std/src/structured-clone.ts
@@ -1,4 +1,5 @@
-import { Result } from "antithrow/legacy";
+import type { Settled } from "antithrow";
+import { Result } from "antithrow";
 
 /**
  * Non-throwing wrapper around `globalThis.structuredClone(...)`.
@@ -19,11 +20,11 @@ import { Result } from "antithrow/legacy";
  * @param value - The value to clone.
  * @param options - An optional object containing transfer options.
  *
- * @returns A `Result` containing the cloned value or the thrown error.
+ * @returns A `Settled` result containing the cloned value or the thrown error.
  */
 export function structuredClone<T>(
 	value: T,
 	options?: StructuredSerializeOptions,
-): Result<T, DOMException> {
+): Settled<T, DOMException> {
 	return Result.try(() => globalThis.structuredClone(value, options));
 }

--- a/packages/std/src/uri.ts
+++ b/packages/std/src/uri.ts
@@ -1,4 +1,5 @@
-import { Result } from "antithrow/legacy";
+import type { Settled } from "antithrow";
+import { Result } from "antithrow";
 
 /**
  * Non-throwing wrapper around `globalThis.decodeURI(...)`.
@@ -11,10 +12,10 @@ import { Result } from "antithrow/legacy";
  *
  * @param encodedURI - The encoded URI to decode.
  *
- * @returns A `Result` containing the decoded URI or the thrown error.
+ * @returns A `Settled` result containing the decoded URI or the thrown error.
  */
 // biome-ignore lint/suspicious/noShadowRestrictedNames: intentionally wrapping the global
-export function decodeURI(encodedURI: string): Result<string, URIError> {
+export function decodeURI(encodedURI: string): Settled<string, URIError> {
 	return Result.try(() => globalThis.decodeURI(encodedURI));
 }
 
@@ -29,10 +30,10 @@ export function decodeURI(encodedURI: string): Result<string, URIError> {
  *
  * @param encodedURIComponent - The encoded URI component to decode.
  *
- * @returns A `Result` containing the decoded URI component or the thrown error.
+ * @returns A `Settled` result containing the decoded URI component or the thrown error.
  */
 // biome-ignore lint/suspicious/noShadowRestrictedNames: intentionally wrapping the global
-export function decodeURIComponent(encodedURIComponent: string): Result<string, URIError> {
+export function decodeURIComponent(encodedURIComponent: string): Settled<string, URIError> {
 	return Result.try(() => globalThis.decodeURIComponent(encodedURIComponent));
 }
 
@@ -47,10 +48,10 @@ export function decodeURIComponent(encodedURIComponent: string): Result<string, 
  *
  * @param uri - The URI to encode.
  *
- * @returns A `Result` containing the encoded URI or the thrown error.
+ * @returns A `Settled` result containing the encoded URI or the thrown error.
  */
 // biome-ignore lint/suspicious/noShadowRestrictedNames: intentionally wrapping the global
-export function encodeURI(uri: string): Result<string, URIError> {
+export function encodeURI(uri: string): Settled<string, URIError> {
 	return Result.try(() => globalThis.encodeURI(uri));
 }
 
@@ -65,11 +66,11 @@ export function encodeURI(uri: string): Result<string, URIError> {
  *
  * @param uriComponent - The URI component to encode.
  *
- * @returns A `Result` containing the encoded URI component or the thrown error.
+ * @returns A `Settled` result containing the encoded URI component or the thrown error.
  */
 // biome-ignore lint/suspicious/noShadowRestrictedNames: intentionally wrapping the global
 export function encodeURIComponent(
 	uriComponent: string | number | boolean,
-): Result<string, URIError> {
+): Settled<string, URIError> {
 	return Result.try(() => globalThis.encodeURIComponent(uriComponent));
 }


### PR DESCRIPTION
## Description

The std package has still been using legacy imports, this change moves to the modern API.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [x] Changeset added (if applicable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `@antithrow/std` wrappers from `ResultAsync` to `Result`/`Settled` return types
> - Replaces `ResultAsync` (from `antithrow/legacy`) with `Result` and `Settled` (from `antithrow`) across all wrappers: `fetch`, `Response` body methods, `JSON`, `base64`, `URI`, and `structuredClone`.
> - Async wrappers now return a `Result` that is `Pending` until the underlying `Promise` settles, rather than a `ResultAsync` instance.
> - Updates all documentation, examples, and reference pages to reflect the new types and static `Response.*` method signatures.
> - Behavioral Change: this is a major version bump — callers expecting `ResultAsync` will need to update to the modern `Result`/`Settled` API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0453de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->