### PR TITLE
feat: migrate `@antithrow/standard-schema` from legacy to modern APIs

### DIFF
--- a/.changeset/fair-cups-jump.md
+++ b/.changeset/fair-cups-jump.md
@@ -1,0 +1,5 @@
+---
+"@antithrow/standard-schema": major
+---
+
+deps!: use modern `Result`/`Settled` APIs instead of `Result`/`ResultAsync`

--- a/apps/docs/docs/how-to/standard-schema/choose-sync-vs-async.md
+++ b/apps/docs/docs/how-to/standard-schema/choose-sync-vs-async.md
@@ -17,7 +17,7 @@ description: Decide between validate and validateSync based on whether the schem
 const result = await validate(schema, input);
 ```
 
-Returns `ResultAsync<T, FailureResult>`.
+Returns `Result<T, FailureResult>`. If the schema is async, that `Result` will be `Pending` until it settles.
 
 ## Use `validateSync` only when you know the schema is sync
 
@@ -28,7 +28,7 @@ Returns `ResultAsync<T, FailureResult>`.
 const result = validateSync(schema, input);
 ```
 
-Returns `Result<T, FailureResult>`.
+Returns `Settled<T, FailureResult>`.
 
 ## What goes wrong if you pick sync and the schema is async
 

--- a/apps/docs/docs/how-to/standard-schema/validate-a-form.md
+++ b/apps/docs/docs/how-to/standard-schema/validate-a-form.md
@@ -1,6 +1,6 @@
 ---
 title: Validate a form
-description: Turn a form submission into a typed Result, attaching issues back to fields.
+description: Turn a form submission into a typed validation result, attaching issues back to fields.
 ---
 
 # Validate a form

--- a/apps/docs/docs/how-to/standard-schema/validate-with-zod.md
+++ b/apps/docs/docs/how-to/standard-schema/validate-with-zod.md
@@ -43,7 +43,7 @@ const result = await validate(UserSchema, input);
 
 ## Sync vs async
 
-Zod supports `async` refinements (e.g. `.refine(async (v) => ...)`). `validate` handles both. If you know your schema has no async pieces, `validateSync` avoids the `await`.
+Zod supports `async` refinements (e.g. `.refine(async (v) => ...)`). `validate` handles both: sync schemas settle immediately, async schemas return `Pending` until awaited. If you know your schema has no async pieces, `validateSync` returns a settled result without the `await`.
 
 ## See also
 

--- a/apps/docs/docs/reference/standard-schema/api.md
+++ b/apps/docs/docs/reference/standard-schema/api.md
@@ -17,10 +17,10 @@ function validate<S extends StandardSchemaV1>(
 	schema: S,
 	value: unknown,
 	options?: StandardSchemaV1.Options,
-): ResultAsync<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult>;
+): Result<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult>;
 ```
 
-Always returns a `ResultAsync` because Standard Schema validators may be synchronous or asynchronous. Exceptions thrown or promise rejections from the validator are converted into a synthetic `FailureResult` with a single issue carrying the error message.
+Returns a `Result`. Synchronous validators settle immediately as `Ok` or `Err`; asynchronous validators return `Pending`, and `await validate(...)` yields a `Settled`. Exceptions thrown or promise rejections from the validator are converted into a synthetic `FailureResult` with a single issue carrying the error message.
 
 ## `validateSync(schema, value, options?)`
 
@@ -29,10 +29,10 @@ function validateSync<S extends StandardSchemaV1>(
 	schema: S,
 	value: unknown,
 	options?: StandardSchemaV1.Options,
-): Result<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult>;
+): Settled<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult>;
 ```
 
-Synchronous variant. Exceptions thrown by the validator are converted into a synthetic `FailureResult`.
+Synchronous variant. Returns a settled `Ok` or `Err`. Exceptions thrown by the validator are converted into a synthetic `FailureResult`.
 
 ## `StandardSchemaV1.FailureResult`
 

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -15,17 +15,18 @@ Schema validation libraries like [Zod](https://zod.dev), [Valibot](https://valib
 [ArkType](https://arktype.io) all implement the
 [Standard Schema](https://github.com/standard-schema/standard-schema) spec.
 `@antithrow/standard-schema` wraps any Standard Schema–conforming validator so validation
-results come back as `Result` / `ResultAsync` instead of raw success/failure objects.
+results come back as `Result` / `Settled` instead of raw success/failure objects.
 
 ```ts
 import { validate } from "@antithrow/standard-schema";
 import { z } from "zod";
 
 const result = await validate(z.string().email(), input);
-result.match({
-  ok: (email) => console.log("valid:", email),
-  err: ({ issues }) => console.error("invalid:", issues),
-});
+if (result.isOk()) {
+	console.log("valid:", result.value);
+} else {
+	console.error("invalid:", result.error.issues);
+}
 ```
 
 ## Installation
@@ -38,8 +39,8 @@ bun add @antithrow/standard-schema
 
 ### Async validation (recommended)
 
-`validate` always returns a `ResultAsync` because Standard Schema validators may be
-synchronous or asynchronous — the caller doesn't need to know which.
+`validate` returns a `Result`. Sync schemas settle immediately as `Ok` or `Err`;
+async schemas return `Pending`, and `await validate(...)` yields a `Settled` result.
 
 ```ts
 import { validate } from "@antithrow/standard-schema";
@@ -50,7 +51,7 @@ const value = result.unwrapOr(fallback);
 
 ### Synchronous validation
 
-`validateSync` returns a plain `Result`. It throws `TypeError` if the schema's
+`validateSync` returns a `Settled` result. It throws `TypeError` if the schema's
 `validate` method returns a `Promise`.
 
 ```ts
@@ -71,9 +72,6 @@ const result = await validate(throwingSchema, input);
 // Err({ issues: [{ message: "..." }] })
 ```
 
-## API Reference
+## Reference
 
-| Export         | Signature                                                                | Returns       |
-| -------------- | ------------------------------------------------------------------------ | ------------- |
-| `validate`     | `(schema, value, options?) → ResultAsync<InferOutput<S>, FailureResult>` | `ResultAsync` |
-| `validateSync` | `(schema, value, options?) → Result<InferOutput<S>, FailureResult>`      | `Result`      |
+Full reference: <https://antithrow.dev/docs/reference/standard-schema>

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@antithrow/standard-schema",
 	"version": "1.0.1",
-	"description": "Bridge Standard Schema validators to antithrow Result/ResultAsync",
+	"description": "Bridge Standard Schema validators to antithrow Result",
 	"license": "MIT",
 	"author": "Jack Weilage",
 	"repository": {

--- a/packages/standard-schema/src/validate.test.ts
+++ b/packages/standard-schema/src/validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, test } from "bun:test";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { Result, ResultAsync } from "antithrow/legacy";
+import type { Result, Settled } from "antithrow";
 import { validate, validateSync } from "./validate.js";
 
 function createSchema<Output>(
@@ -120,11 +120,11 @@ describe("validate", () => {
 		expect(issues[3]?.path).toEqual([{ key: "nested" }]);
 	});
 
-	test("returns ResultAsync", () => {
+	test("returns Result", () => {
 		const schema = createSchema<number>(() => ({ value: 1 }));
 		const result = validate(schema, "anything");
 
-		expectTypeOf(result).toEqualTypeOf<ResultAsync<number, StandardSchemaV1.FailureResult>>();
+		expectTypeOf(result).toEqualTypeOf<Result<number, StandardSchemaV1.FailureResult>>();
 	});
 });
 
@@ -191,11 +191,11 @@ describe("validateSync", () => {
 		expect(result.unwrapErr().issues[0]?.path).toEqual(["a", { key: "b" }]);
 	});
 
-	test("returns Result", () => {
+	test("returns Settled", () => {
 		const schema = createSchema<string>(() => ({ value: "hi" }));
 		const result = validateSync(schema, "anything");
 
-		expectTypeOf(result).toEqualTypeOf<Result<string, StandardSchemaV1.FailureResult>>();
+		expectTypeOf(result).toEqualTypeOf<Settled<string, StandardSchemaV1.FailureResult>>();
 	});
 });
 

--- a/packages/standard-schema/src/validate.ts
+++ b/packages/standard-schema/src/validate.ts
@@ -1,37 +1,47 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { err, ok, Result, ResultAsync } from "antithrow/legacy";
+import type { Settled } from "antithrow";
+import { Err, Ok, Result } from "antithrow";
 
 function toFailureResult(error: unknown): StandardSchemaV1.FailureResult {
 	const message = error instanceof Error ? error.message : String(error);
 	return { issues: [{ message }] };
 }
 
+function isThenable<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+	return (
+		value !== null &&
+		(typeof value === "object" || typeof value === "function") &&
+		typeof (value as { then?: unknown }).then === "function"
+	);
+}
+
 function convertResult<Output>(
 	result: StandardSchemaV1.Result<Output>,
-): Result<Output, StandardSchemaV1.FailureResult> {
+): Settled<Output, StandardSchemaV1.FailureResult> {
 	if (result.issues) {
-		return err(result);
+		return new Err(result);
 	}
 
-	return ok(result.value);
+	return new Ok(result.value);
 }
 
 /**
- * Validates a value against a Standard Schema, returning a `ResultAsync`.
+ * Validates a value against a Standard Schema, returning a `Result`.
  *
- * Always returns `ResultAsync` because Standard Schema validators may return
- * either a synchronous result or a `Promise`. Exceptions thrown or rejected
- * by the validator are caught and wrapped in a synthetic `FailureResult`.
+ * Synchronous validators return a settled `Ok` or `Err` immediately. Async
+ * validators return `Pending`. Exceptions thrown or rejected by the validator are caught and
+ * wrapped in a synthetic `FailureResult`.
  *
  * @example
  * ```ts
  * import { validate } from "@antithrow/standard-schema";
  *
  * const result = await validate(mySchema, input);
- * result.match({
- *   ok: (value) => console.log("valid:", value),
- *   err: ({ issues }) => console.error("invalid:", issues),
- * });
+ * if (result.isOk()) {
+ * 	console.log("valid:", result.value);
+ * } else {
+ * 	console.error("invalid:", result.error.issues);
+ * }
  * ```
  *
  * @template S - The Standard Schema type.
@@ -40,20 +50,29 @@ function convertResult<Output>(
  * @param value - The value to validate.
  * @param options - Optional validation options forwarded to the schema.
  *
- * @returns A `ResultAsync` containing the validated output or a `FailureResult`.
+ * @returns A `Result` containing the validated output or a `FailureResult`.
  */
 export function validate<S extends StandardSchemaV1>(
 	schema: S,
 	value: unknown,
 	options?: StandardSchemaV1.Options,
-): ResultAsync<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult> {
-	return ResultAsync.try(() => schema["~standard"].validate(value, options))
-		.mapErr(toFailureResult)
-		.andThen(convertResult);
+): Result<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult> {
+	let result: StandardSchemaV1.Result<unknown> | PromiseLike<StandardSchemaV1.Result<unknown>>;
+	try {
+		result = schema["~standard"].validate(value, options);
+	} catch (error) {
+		return new Err(toFailureResult(error));
+	}
+
+	if (isThenable(result)) {
+		return Result.fromPromise(result).mapErr(toFailureResult).andThen(convertResult);
+	}
+
+	return convertResult(result);
 }
 
 /**
- * Validates a value against a Standard Schema synchronously, returning a `Result`.
+ * Validates a value against a Standard Schema synchronously, returning a `Settled` result.
  *
  * Throws `TypeError` if the schema returns a `Promise`, since that indicates
  * an asynchronous validator was passed to a synchronous call site. Use
@@ -67,10 +86,11 @@ export function validate<S extends StandardSchemaV1>(
  * import { validateSync } from "@antithrow/standard-schema";
  *
  * const result = validateSync(mySchema, input);
- * result.match({
- *   ok: (value) => console.log("valid:", value),
- *   err: ({ issues }) => console.error("invalid:", issues),
- * });
+ * if (result.isOk()) {
+ * 	console.log("valid:", result.value);
+ * } else {
+ * 	console.error("invalid:", result.error.issues);
+ * }
  * ```
  *
  * @template S - The Standard Schema type.
@@ -79,7 +99,7 @@ export function validate<S extends StandardSchemaV1>(
  * @param value - The value to validate.
  * @param options - Optional validation options forwarded to the schema.
  *
- * @returns A `Result` containing the validated output or a `FailureResult`.
+ * @returns A `Settled` result containing the validated output or a `FailureResult`.
  *
  * @throws {TypeError} If the schema's `validate` method returns a `Promise`.
  */
@@ -87,16 +107,19 @@ export function validateSync<S extends StandardSchemaV1>(
 	schema: S,
 	value: unknown,
 	options?: StandardSchemaV1.Options,
-): Result<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult> {
-	return Result.try(() => schema["~standard"].validate(value, options))
-		.mapErr(toFailureResult)
-		.andThen((result) => {
-			if (result instanceof Promise) {
-				throw new TypeError(
-					"Schema returned a Promise from validate(). Use validate() instead of validateSync() for async schemas.",
-				);
-			}
+): Settled<StandardSchemaV1.InferOutput<S>, StandardSchemaV1.FailureResult> {
+	let result: StandardSchemaV1.Result<unknown> | PromiseLike<StandardSchemaV1.Result<unknown>>;
+	try {
+		result = schema["~standard"].validate(value, options);
+	} catch (error) {
+		return new Err(toFailureResult(error));
+	}
 
-			return convertResult(result);
-		});
+	if (isThenable(result)) {
+		throw new TypeError(
+			"Schema returned a Promise from validate(). Use validate() instead of validateSync() for async schemas.",
+		);
+	}
+
+	return convertResult(result);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [x] Changeset added (if applicable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `@antithrow/standard-schema` from legacy `ResultAsync` to modern `Result`/`Settled` APIs
> - `validate()` now returns a `Result` that is settled immediately for synchronous schemas and pending for asynchronous schemas, replacing the previous `ResultAsync` return type.
> - `validateSync()` now returns `Settled` (an `Ok` or `Err`) instead of `Result`; it still throws `TypeError` when called with an async schema.
> - Internal implementation adds an `isThenable` type guard and replaces legacy `ok`/`err` helpers with direct `Ok`/`Err` class instantiation.
> - README, reference docs, and how-to guides are updated to reflect the new API terminology and usage patterns.
> - Behavioral Change: callers relying on `ResultAsync` from `validate()` or `Result` from `validateSync()` must update their types and handling code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a65ead3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->