### PR TITLE
feat: migrate eslint plugin to new APIs

### DIFF
--- a/.changeset/modernize-eslint-plugin.md
+++ b/.changeset/modernize-eslint-plugin.md
@@ -1,0 +1,9 @@
+---
+"@antithrow/eslint-plugin": major
+---
+
+deps!: target modern `Result`/`Settled` APIs instead of `Result`/`ResultAsync`
+
+Rules now analyze values typed against the modern `antithrow` entrypoint (`Ok`, `Err`, `Pending`). Values from `antithrow/legacy` are no longer flagged.
+
+`no-unsafe-unwrap` no longer reports `.expect()` and `.expectErr()`, since the modern API does not expose those methods. It now also reports `.unwrap()` / `.unwrapErr()` on `Pending`, where they return a promise that may reject rather than a value.

--- a/apps/docs/docs/reference/eslint-plugin/no-unsafe-unwrap.md
+++ b/apps/docs/docs/reference/eslint-plugin/no-unsafe-unwrap.md
@@ -1,6 +1,6 @@
 ---
 title: no-unsafe-unwrap
-description: Disallow unsafe unwrap APIs on Result and ResultAsync values.
+description: Disallow unsafe unwrap APIs on Result values.
 sidebar_position: 2
 ---
 
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 Rule id: `@antithrow/no-unsafe-unwrap`
 
-Reports calls to methods that will throw if the `Result` is in the wrong variant: `unwrap`, `unwrapErr`, `expect`, `expectErr`.
+Reports calls to methods that will throw if the `Result` is in the wrong variant: `unwrap` and `unwrapErr`.
 
 ## Metadata
 
@@ -42,7 +42,7 @@ When the static type is known to be `Ok<...>`, calls to `.unwrap()` are rewritte
 
 When the static type is known to be `Err<...>`, calls to `.unwrapErr()` are rewritten to `.error`.
 
-All other cases are reported without a fix, since removing the throw requires the author to decide how to handle both branches.
+All other cases — including any type that includes `Pending<...>`, where `.unwrap()` returns a promise instead of a value — are reported without a fix, since removing the throw requires the author to decide how to handle every branch.
 
 ## Example
 

--- a/apps/docs/docs/reference/eslint-plugin/no-unused-result.md
+++ b/apps/docs/docs/reference/eslint-plugin/no-unused-result.md
@@ -1,6 +1,6 @@
 ---
 title: no-unused-result
-description: Require Result and ResultAsync values to be used, preventing silently ignored errors.
+description: Require Result values to be used, preventing silently ignored errors.
 sidebar_position: 3
 ---
 
@@ -8,7 +8,9 @@ sidebar_position: 3
 
 Rule id: `@antithrow/no-unused-result`
 
-Reports expression statements whose value is a `Result` or `ResultAsync` — the analog of `no-unused-expressions` for typed errors. A `Result` that is never inspected is a silently-dropped error.
+Reports expression statements whose value is a `Result` — the analog of `no-unused-expressions` for typed errors. A `Result` that is never inspected is a silently-dropped error.
+
+Applies to values whose type includes `Ok<T, E>`, `Err<T, E>`, or `Pending<T, E>` from the root `antithrow` entrypoint. Values from the legacy `antithrow/legacy` entrypoint are ignored.
 
 ## Metadata
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -49,10 +49,6 @@ export default [
 ];
 ```
 
-## Rules
+## Reference
 
-| Rule                                                   | Description                                                                 | Recommended |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- | ----------- |
-| [`no-throwing-call`](https://antithrow.dev/docs/api/eslint-plugin/no-throwing-call) | Disallow calls to throwing built-in APIs with `@antithrow/std` replacements | `warn`      |
-| [`no-unsafe-unwrap`](https://antithrow.dev/docs/api/eslint-plugin/no-unsafe-unwrap) | Disallow `unwrap`/`expect` APIs on antithrow `Result` values                | `warn`      |
-| [`no-unused-result`](https://antithrow.dev/docs/api/eslint-plugin/no-unused-result) | Require `Result` and `ResultAsync` values to be used                        | `error`     |
+Full rule reference: <https://antithrow.dev/docs/reference/eslint-plugin>

--- a/packages/eslint-plugin/src/rules/no-unsafe-unwrap.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-unwrap.test.ts
@@ -1,7 +1,7 @@
 import { MessageId, noUnsafeUnwrap } from "./no-unsafe-unwrap.js";
 import { createCodeHelper, ruleTester } from "./utils/test-utils.js";
 
-const preamble = `import { ok, err, okAsync, errAsync, Result } from "antithrow/legacy";\n`;
+const preamble = `import { Ok, Err, Pending, Result, type Settled } from "antithrow";\n`;
 const code = createCodeHelper(preamble);
 
 ruleTester.run("no-unsafe-unwrap", noUnsafeUnwrap, {
@@ -15,16 +15,16 @@ ruleTester.run("no-unsafe-unwrap", noUnsafeUnwrap, {
 			code: `function unwrap(value: number) { return value; }\nunwrap(1);`,
 		},
 		{
-			name: "safe result api match",
-			code: code`ok(1).match({ ok: (value) => value, err: (_error) => 0 });`,
+			name: "safe result api mapOr",
+			code: code`new Ok(1).mapOr(0, (value) => value);`,
 		},
 		{
 			name: "safe result api unwrapOr",
-			code: code`ok(1).unwrapOr(0);`,
+			code: code`new Ok(1).unwrapOr(0);`,
 		},
 		{
 			name: "dynamic bracket access is ignored",
-			code: code`const result = ok(1);\nconst method = "unwrap";\nresult[method]();`,
+			code: code`const result = new Ok(1);\nconst method = "unwrap";\nresult[method]();`,
 		},
 		{
 			name: "destructuring from non-result object",
@@ -36,151 +36,156 @@ ruleTester.run("no-unsafe-unwrap", noUnsafeUnwrap, {
 		},
 		{
 			name: "computed identifier key destructuring in function parameter is ignored",
-			code: code`const method = "unwrap" as const;\nfunction take({ [method]: fn }: Result<number, string>) { return fn; }`,
+			code: code`const method = "unwrap" as const;\nfunction take({ [method]: fn }: Settled<number, string>) { return fn; }`,
 		},
 		{
 			name: "computed identifier key destructuring is ignored",
-			code: code`const result = ok(1);\nconst method = "unwrap" as const;\nconst { [method]: fn } = result;`,
+			code: code`const result = new Ok(1);\nconst method = "unwrap" as const;\nconst { [method]: fn } = result;`,
 		},
 		{
 			name: "destructuring non-banned property from Result is allowed",
-			code: code`const result = ok(1);\nconst { map } = result;`,
+			code: code`const result = new Ok(1);\nconst { map } = result;`,
 		},
 		{
 			name: "numeric literal key destructuring is ignored",
 			code: `const values = { 1: "one" };\nconst { 1: one } = values;\nvoid one;`,
 		},
 		{
-			name: "root antithrow unwrap is ignored",
-			code: `import { Ok } from "antithrow";\nnew Ok(1).unwrap();`,
+			name: "legacy antithrow unwrap is ignored",
+			code: `import { ok } from "antithrow/legacy";\nok(1).unwrap();`,
 		},
 	],
 	invalid: [
 		{
-			name: "unwrap call on Result",
-			code: code`ok(1).unwrap();`,
-			output: code`ok(1).value;`,
+			name: "unwrap call on Ok",
+			code: code`new Ok(1).unwrap();`,
+			output: code`new Ok(1).value;`,
 			errors: [{ messageId: MessageId.UNWRAP_OK_VALUE }],
 		},
 		{
 			name: "escaped unwrap identifier on Ok is reported without autofix",
-			code: code`ok(1).unw\\u0072ap();`,
+			code: code`new Ok(1).unw\\u0072ap();`,
 			output: null,
 			errors: [{ messageId: MessageId.UNWRAP_OK_VALUE }],
 		},
 		{
-			name: "unwrapErr call on Result",
-			code: code`err("x").unwrapErr();`,
-			output: code`err("x").error;`,
+			name: "unwrapErr call on Err",
+			code: code`new Err("x").unwrapErr();`,
+			output: code`new Err("x").error;`,
 			errors: [{ messageId: MessageId.UNWRAP_ERR_ERROR }],
 		},
 		{
 			name: "escaped unwrapErr identifier on Err is reported without autofix",
-			code: code`err("x").unwrap\\u0045rr();`,
+			code: code`new Err("x").unwrap\\u0045rr();`,
 			output: null,
 			errors: [{ messageId: MessageId.UNWRAP_ERR_ERROR }],
 		},
 		{
-			name: "expect call on Result",
-			code: code`ok(1).expect("expected value");`,
+			name: "unwrap call on Err",
+			code: code`new Err("x").unwrap();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
-			name: "expectErr call on Result",
-			code: code`err("x").expectErr("expected error");`,
+			name: "unwrapErr call on Ok",
+			code: code`new Ok(1).unwrapErr();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
-			name: "unwrap call on ResultAsync",
-			code: code`okAsync(1).unwrap();`,
+			name: "unwrap call on Pending",
+			code: code`declare const pending: Pending<number, string>;\npending.unwrap();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
-			name: "expectErr call on ResultAsync",
-			code: code`errAsync("x").expectErr("expected error");`,
+			name: "unwrapErr call on Pending",
+			code: code`declare const pending: Pending<number, string>;\npending.unwrapErr();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
-			name: "optional unwrap call",
-			code: code`declare const result: Result<number, string> | undefined;\nresult?.unwrap();`,
+			name: "optional unwrap call on Settled",
+			code: code`declare const result: Settled<number, string> | undefined;\nresult?.unwrap();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "optional unwrap call on optional Ok",
-			code: code`declare const result: ReturnType<typeof ok> | undefined;\nresult?.unwrap();`,
-			output: code`declare const result: ReturnType<typeof ok> | undefined;\nresult?.value;`,
+			code: code`declare const result: Ok<number, never> | undefined;\nresult?.unwrap();`,
+			output: code`declare const result: Ok<number, never> | undefined;\nresult?.value;`,
 			errors: [{ messageId: MessageId.UNWRAP_OK_VALUE }],
 		},
 		{
 			name: "optional computed unwrap call on optional Ok",
-			code: code`declare const result: ReturnType<typeof ok> | undefined;\nresult?.["unwrap"]();`,
-			output: code`declare const result: ReturnType<typeof ok> | undefined;\nresult?.value;`,
+			code: code`declare const result: Ok<number, never> | undefined;\nresult?.["unwrap"]();`,
+			output: code`declare const result: Ok<number, never> | undefined;\nresult?.value;`,
 			errors: [{ messageId: MessageId.UNWRAP_OK_VALUE }],
 		},
 		{
-			name: "unwrap call on unresolved Result union",
+			name: "unwrap call on Result union (includes Pending)",
 			code: code`declare const result: Result<number, string>;\nresult.unwrap();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
+			name: "unwrap call on Settled union",
+			code: code`declare const result: Settled<number, string>;\nresult.unwrap();`,
+			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
+		},
+		{
 			name: "unwrap call on mixed Ok and non-Result union",
-			code: code`type Box = { unwrap(): number };\ndeclare const result: ReturnType<typeof ok> | Box;\nresult.unwrap();`,
+			code: code`type Box = { unwrap(): number };\ndeclare const result: Ok<number, never> | Box;\nresult.unwrap();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "static bracket unwrap",
-			code: code`const result = ok(1);\nresult["unwrap"]();`,
-			output: code`const result = ok(1);\nresult.value;`,
+			code: code`const result = new Ok(1);\nresult["unwrap"]();`,
+			output: code`const result = new Ok(1);\nresult.value;`,
 			errors: [{ messageId: MessageId.UNWRAP_OK_VALUE }],
 		},
 		{
-			name: "static template bracket expect",
-			code: code`const result = err("x");\nresult[\`expectErr\`]("expected error");`,
+			name: "static template bracket unwrap on Pending",
+			code: code`declare const pending: Pending<number, string>;\npending[\`unwrap\`]();`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "property extraction from Result",
-			code: code`const result = ok(1);\nconst fn = result.unwrap;`,
+			code: code`const result = new Ok(1);\nconst fn = result.unwrap;`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "destructuring extraction from Result",
-			code: code`const result = ok(1);\nconst { unwrap } = result;`,
+			code: code`const result = new Ok(1);\nconst { unwrap } = result;`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "destructuring extraction alias from Result",
-			code: code`const result = err("x");\nconst { expectErr: unwrapError } = result;`,
+			code: code`const result = new Err("x");\nconst { unwrapErr: unwrapError } = result;`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "assignment destructuring extraction from Result",
-			code: code`const result = ok(1);\nlet unwrap: (() => number) | undefined;\n({ unwrap } = result);`,
+			code: code`const result = new Ok(1);\nlet unwrap: (() => number) | undefined;\n({ unwrap } = result);`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "computed literal key destructuring extraction from Result",
-			code: code`const result = ok(1);\nconst { ["unwrap"]: fn } = result;`,
+			code: code`const result = new Ok(1);\nconst { ["unwrap"]: fn } = result;`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "computed template key destructuring extraction from Result",
-			code: code`const result = err("x");\nconst { [\`expectErr\`]: fn } = result;`,
+			code: code`const result = new Err("x");\nconst { [\`unwrapErr\`]: fn } = result;`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
 			name: "string literal key destructuring extraction from Result",
-			code: code`const result = ok(1);\nconst { "unwrap": fn } = result;`,
+			code: code`const result = new Ok(1);\nconst { "unwrap": fn } = result;`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
-			name: "destructured function parameter from Result",
-			code: code`function take({ unwrap }: Result<number, string>) { return unwrap; }`,
+			name: "destructured function parameter from Settled",
+			code: code`function take({ unwrap }: Settled<number, string>) { return unwrap; }`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 		{
-			name: "destructured for-of loop from Result",
-			code: code`declare const results: Result<number, string>[];\nfor (const { unwrap } of results) { void unwrap; }`,
+			name: "destructured for-of loop from Settled",
+			code: code`declare const results: Settled<number, string>[];\nfor (const { unwrap } of results) { void unwrap; }`,
 			errors: [{ messageId: MessageId.UNSAFE_UNWRAP }],
 		},
 	],

--- a/packages/eslint-plugin/src/rules/no-unsafe-unwrap.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-unwrap.ts
@@ -12,7 +12,7 @@ export const MessageId = {
 } as const;
 export type MessageId = (typeof MessageId)[keyof typeof MessageId];
 
-const BANNED_METHOD_NAMES = new Set(["unwrap", "unwrapErr", "expect", "expectErr"]);
+const BANNED_METHOD_NAMES = new Set(["unwrap", "unwrapErr"]);
 const FIXABLE_OK_METHOD_NAMES = new Set(["unwrap"]);
 const FIXABLE_ERR_METHOD_NAMES = new Set(["unwrapErr"]);
 
@@ -52,8 +52,7 @@ export const noUnsafeUnwrap = createRule<[], MessageId>({
 		type: "problem",
 		fixable: "code",
 		docs: {
-			description:
-				"Disallow unsafe unwrap APIs on Result and ResultAsync values to prevent unexpected throws.",
+			description: "Disallow unsafe unwrap APIs on Result values to prevent unexpected throws.",
 			recommended: true,
 			requiresTypeChecking: true,
 		},

--- a/packages/eslint-plugin/src/rules/no-unused-result.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-result.test.ts
@@ -1,34 +1,34 @@
 import { MessageId, noUnusedResult } from "./no-unused-result.js";
 import { createCodeHelper, ruleTester } from "./utils/test-utils.js";
 
-const preamble = `import { ok, err, okAsync, errAsync, Result, ResultAsync } from "antithrow/legacy";\n`;
+const preamble = `import { Ok, Err, Pending, Result, type Settled } from "antithrow";\n`;
 const code = createCodeHelper(preamble);
 
 ruleTester.run("no-unused-result", noUnusedResult, {
 	valid: [
 		{
 			name: "assigned to variable",
-			code: code`const x = ok(1);`,
+			code: code`const x = new Ok(1);`,
 		},
 		{
 			name: "assigned to underscore",
-			code: code`let _ = ok(1);`,
+			code: code`let _ = new Ok(1);`,
 		},
 		{
 			name: "returned from function",
-			code: code`function f() { return ok(1); }`,
+			code: code`function f() { return new Ok(1); }`,
 		},
 		{
 			name: "passed as argument",
-			code: code`function foo(r: Result<number, never>) {} foo(ok(1));`,
+			code: code`function foo(r: Settled<number, never>) {} foo(new Ok(1));`,
 		},
 		{
 			name: "explicit void discard",
-			code: code`void ok(1);`,
+			code: code`void new Ok(1);`,
 		},
 		{
 			name: "chain ending in unwrap (non-Result)",
-			code: code`ok(1).unwrap();`,
+			code: code`new Ok(1).unwrap();`,
 		},
 		{
 			name: "non-Result expression statement",
@@ -43,98 +43,103 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 			code: code`console.log("hi");`,
 		},
 		{
-			name: "ResultAsync assigned in async function",
-			code: code`async function f() { const x = await okAsync(1); }`,
+			name: "Pending awaited in async function",
+			code: code`async function f() { const x = await Result.try(async () => 1); }`,
 		},
 		{
-			name: "match returns non-Result",
-			code: code`ok(1).match({ ok: (v) => v, err: (e) => 0 });`,
+			name: "mapOrElse returns non-Result",
+			code: code`new Ok(1).mapOrElse((_error) => 0, (value) => value);`,
 		},
 		{
 			name: "ternary with both branches voided",
-			code: code`declare const cond: boolean;\ncond ? void ok(1) : void ok(2);`,
+			code: code`declare const cond: boolean;\ncond ? void new Ok(1) : void new Ok(2);`,
 		},
 		{
 			name: "logical AND with voided Result",
-			code: code`true && void ok(1);`,
+			code: code`true && void new Ok(1);`,
 		},
 		{
 			name: "entire ternary voided",
-			code: code`declare const cond: boolean;\nvoid (cond ? ok(1) : ok(2));`,
+			code: code`declare const cond: boolean;\nvoid (cond ? new Ok(1) : new Ok(2));`,
 		},
 		{
-			name: "root antithrow Ok is ignored",
-			code: `import { Ok } from "antithrow";\nnew Ok(1);`,
+			name: "legacy antithrow Ok is ignored",
+			code: `import { ok } from "antithrow/legacy";\nok(1);`,
 		},
 	],
 	invalid: [
 		{
-			name: "bare ok() expression",
-			code: code`ok(1);`,
+			name: "bare Ok expression",
+			code: code`new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void ok(1);` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void new Ok(1);` }],
 				},
 			],
 		},
 		{
-			name: "bare err() expression",
-			code: code`err("x");`,
+			name: "bare Err expression",
+			code: code`new Err("x");`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void err("x");` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void new Err("x");` }],
 				},
 			],
 		},
 		{
 			name: "chain still produces Result (map), unused",
-			code: code`ok(1).map(x => x + 1);`,
+			code: code`new Ok(1).map(x => x + 1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
-						{ messageId: MessageId.ADD_VOID, output: code`void ok(1).map(x => x + 1);` },
+						{ messageId: MessageId.ADD_VOID, output: code`void new Ok(1).map(x => x + 1);` },
 					],
 				},
 			],
 		},
 		{
-			name: "bare okAsync() expression",
-			code: code`okAsync(1);`,
-			errors: [
-				{
-					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void okAsync(1);` }],
-				},
-			],
-		},
-		{
-			name: "function returning Result, unused",
-			code: code`function getResult(): Result<number, string> { return ok(1); } getResult();`,
+			name: "bare Pending expression from Result.try",
+			code: code`Result.try(async () => 1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`function getResult(): Result<number, string> { return ok(1); } void getResult();`,
+							output: code`void Result.try(async () => 1);`,
 						},
 					],
 				},
 			],
 		},
 		{
-			name: "awaited okAsync produces Result, unused",
-			code: code`async function f() { await okAsync(1); }`,
+			name: "function returning Settled, unused",
+			code: code`function getResult(): Settled<number, string> { return new Ok(1); } getResult();`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`async function f() { void await okAsync(1); }`,
+							output: code`function getResult(): Settled<number, string> { return new Ok(1); } void getResult();`,
+						},
+					],
+				},
+			],
+		},
+		{
+			name: "awaited Pending produces Settled, unused",
+			code: code`async function f() { await Result.try(async () => 1); }`,
+			errors: [
+				{
+					messageId: MessageId.UNUSED_RESULT,
+					suggestions: [
+						{
+							messageId: MessageId.ADD_VOID,
+							output: code`async function f() { void await Result.try(async () => 1); }`,
 						},
 					],
 				},
@@ -142,36 +147,41 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "chain producing Result (mapErr), unused",
-			code: code`ok(1).mapErr(e => e);`,
+			code: code`new Ok(1).mapErr(e => e);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
-						{ messageId: MessageId.ADD_VOID, output: code`void ok(1).mapErr(e => e);` },
+						{ messageId: MessageId.ADD_VOID, output: code`void new Ok(1).mapErr(e => e);` },
 					],
 				},
 			],
 		},
 		{
-			name: "bare errAsync() expression",
-			code: code`errAsync("x");`,
-			errors: [
-				{
-					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void errAsync("x");` }],
-				},
-			],
-		},
-		{
-			name: "Result with ts as-cast, unused",
-			code: code`ok(1) as Result<number, never>;`,
+			name: "bare Pending identifier expression",
+			code: code`declare const pending: Pending<number, string>;\npending;`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`void (ok(1) as Result<number, never>);`,
+							output: code`declare const pending: Pending<number, string>;\nvoid pending;`,
+						},
+					],
+				},
+			],
+		},
+		{
+			name: "Result with ts as-cast, unused",
+			code: code`new Ok(1) as Settled<number, never>;`,
+			errors: [
+				{
+					messageId: MessageId.UNUSED_RESULT,
+					suggestions: [
+						{
+							messageId: MessageId.ADD_VOID,
+							output: code`void (new Ok(1) as Settled<number, never>);`,
 						},
 					],
 				},
@@ -179,14 +189,14 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "Result with non-null assertion, unused",
-			code: code`declare const r: Result<number, string> | undefined;\nr!;`,
+			code: code`declare const r: Settled<number, string> | undefined;\nr!;`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`declare const r: Result<number, string> | undefined;\nvoid r!;`,
+							output: code`declare const r: Settled<number, string> | undefined;\nvoid r!;`,
 						},
 					],
 				},
@@ -194,14 +204,14 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "optional chain producing Result, unused",
-			code: code`declare const o: { f(): Result<number, string> } | undefined;\no?.f();`,
+			code: code`declare const o: { f(): Settled<number, string> } | undefined;\no?.f();`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`declare const o: { f(): Result<number, string> } | undefined;\nvoid o?.f();`,
+							output: code`declare const o: { f(): Settled<number, string> } | undefined;\nvoid o?.f();`,
 						},
 					],
 				},
@@ -209,14 +219,14 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "ternary with both branches producing Result",
-			code: code`declare const cond: boolean;\ncond ? ok(1) : ok(2);`,
+			code: code`declare const cond: boolean;\ncond ? new Ok(1) : new Ok(2);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`declare const cond: boolean;\nvoid (cond ? ok(1) : ok(2));`,
+							output: code`declare const cond: boolean;\nvoid (cond ? new Ok(1) : new Ok(2));`,
 						},
 					],
 				},
@@ -225,7 +235,7 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`declare const cond: boolean;\nvoid (cond ? ok(1) : ok(2));`,
+							output: code`declare const cond: boolean;\nvoid (cond ? new Ok(1) : new Ok(2));`,
 						},
 					],
 				},
@@ -233,24 +243,24 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "logical AND producing Result",
-			code: code`true && ok(1);`,
+			code: code`true && new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void (true && ok(1));` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void (true && new Ok(1));` }],
 				},
 			],
 		},
 		{
 			name: "comma operator with non-final Result discarded",
-			code: code`ok(1), console.log("hi");`,
+			code: code`new Ok(1), console.log("hi");`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`void (ok(1), console.log("hi"));`,
+							output: code`void (new Ok(1), console.log("hi"));`,
 						},
 					],
 				},
@@ -258,24 +268,26 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "logical OR producing Result",
-			code: code`false || ok(1);`,
+			code: code`false || new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void (false || ok(1));` }],
+					suggestions: [
+						{ messageId: MessageId.ADD_VOID, output: code`void (false || new Ok(1));` },
+					],
 				},
 			],
 		},
 		{
 			name: "nullish coalescing producing Result",
-			code: code`declare const cond: null | number;\ncond ?? ok(1);`,
+			code: code`declare const cond: null | number;\ncond ?? new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`declare const cond: null | number;\nvoid (cond ?? ok(1));`,
+							output: code`declare const cond: null | number;\nvoid (cond ?? new Ok(1));`,
 						},
 					],
 				},
@@ -283,44 +295,44 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "unary operator + on Result",
-			code: code`+ ok(1);`,
+			code: code`+ new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void + ok(1);` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void + new Ok(1);` }],
 				},
 			],
 		},
 		{
 			name: "unary operator - on Result",
-			code: code`- ok(1);`,
+			code: code`- new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void - ok(1);` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void - new Ok(1);` }],
 				},
 			],
 		},
 		{
 			name: "unary operator ! on Result",
-			code: code`! ok(1);`,
+			code: code`! new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void ! ok(1);` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void ! new Ok(1);` }],
 				},
 			],
 		},
 		{
 			name: "unary operator ~ on Result",
-			code: code`~ ok(1);`,
+			code: code`~ new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
 					suggestions: [
 						{
 							messageId: MessageId.ADD_VOID,
-							output: code`void ~ ok(1);`,
+							output: code`void ~ new Ok(1);`,
 						},
 					],
 				},
@@ -328,21 +340,21 @@ ruleTester.run("no-unused-result", noUnusedResult, {
 		},
 		{
 			name: "unary operator typeof on Result",
-			code: code`typeof ok(1);`,
+			code: code`typeof new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void typeof ok(1);` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void typeof new Ok(1);` }],
 				},
 			],
 		},
 		{
 			name: "unary operator delete on Result",
-			code: code`delete ok(1);`,
+			code: code`delete new Ok(1);`,
 			errors: [
 				{
 					messageId: MessageId.UNUSED_RESULT,
-					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void delete ok(1);` }],
+					suggestions: [{ messageId: MessageId.ADD_VOID, output: code`void delete new Ok(1);` }],
 				},
 			],
 		},

--- a/packages/eslint-plugin/src/rules/no-unused-result.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-result.ts
@@ -31,8 +31,7 @@ export const noUnusedResult = createRule<[], MessageId>({
 		type: "problem",
 		hasSuggestions: true,
 		docs: {
-			description:
-				"Require Result and ResultAsync values to be used, preventing silently ignored errors.",
+			description: "Require Result values to be used, preventing silently ignored errors.",
 			recommended: true,
 			requiresTypeChecking: true,
 		},

--- a/packages/eslint-plugin/src/rules/utils/result-type.ts
+++ b/packages/eslint-plugin/src/rules/utils/result-type.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 
-const RESULT_TYPE_NAMES = new Set(["Ok", "Err", "ResultAsync"]);
+const RESULT_TYPE_NAMES = new Set(["Ok", "Err", "Pending"]);
 const FIXABLE_OK_TYPE_NAMES = new Set(["Ok"]);
 const FIXABLE_ERR_TYPE_NAMES = new Set(["Err"]);
 export const NULLISH_TYPE_FLAGS = ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
@@ -13,7 +13,7 @@ export const ResultVariant = {
 } as const;
 export type ResultVariant = (typeof ResultVariant)[keyof typeof ResultVariant];
 
-function isAntithrowLegacySourceFile(sourceFileName: string): boolean {
+function isAntithrowSourceFile(sourceFileName: string): boolean {
 	const pathSegments = sourceFileName.replaceAll("\\", "/").split("/");
 
 	for (const [index, segment] of pathSegments.entries()) {
@@ -21,7 +21,7 @@ function isAntithrowLegacySourceFile(sourceFileName: string): boolean {
 			continue;
 		}
 
-		if (pathSegments.slice(index + 1).includes("legacy")) {
+		if (!pathSegments.slice(index + 1).includes("legacy")) {
 			return true;
 		}
 	}
@@ -29,7 +29,7 @@ function isAntithrowLegacySourceFile(sourceFileName: string): boolean {
 	return false;
 }
 
-function isAntithrowLegacyResultTypeSymbol(symbol: ts.Symbol): boolean {
+function isAntithrowResultTypeSymbol(symbol: ts.Symbol): boolean {
 	if (!RESULT_TYPE_NAMES.has(symbol.getName())) {
 		return false;
 	}
@@ -38,7 +38,7 @@ function isAntithrowLegacyResultTypeSymbol(symbol: ts.Symbol): boolean {
 
 	return declarations.some((decl) => {
 		const sourceFile = decl.getSourceFile();
-		return isAntithrowLegacySourceFile(sourceFile.fileName);
+		return isAntithrowSourceFile(sourceFile.fileName);
 	});
 }
 
@@ -62,7 +62,7 @@ function collectResultTypes(type: ts.Type, collection: ResultTypeCollection): vo
 	}
 
 	const symbol = type.getSymbol();
-	if (!(symbol && isAntithrowLegacyResultTypeSymbol(symbol))) {
+	if (!(symbol && isAntithrowResultTypeSymbol(symbol))) {
 		collection.hasNonResultMembers = true;
 		return;
 	}
@@ -86,7 +86,7 @@ export function getResultVariant(type: ts.Type): ResultVariant {
 		return ResultVariant.MIXED;
 	}
 
-	if (names.has("ResultAsync")) {
+	if (names.has("Pending")) {
 		return ResultVariant.MIXED;
 	}
 
@@ -104,11 +104,12 @@ export function getResultVariant(type: ts.Type): ResultVariant {
 /**
  * Determines whether a type originates from antithrow's `Result` family.
  *
- * `Result<T, E>` is a union of `Ok<T, E> | Err<T, E>`, so we recurse into
- * union members. We also guard against `any`/`unknown`/`never` to avoid
- * false positives on untyped code. Finally, we verify the symbol's
- * declaration lives inside the `antithrow/legacy` entrypoint so that unrelated
- * types with the same names (e.g. a user-defined `Ok` class) are not flagged.
+ * `Result<T, E>` is a union of `Ok<T, E> | Err<T, E> | Pending<T, E>`, so we
+ * recurse into union members. We also guard against `any`/`unknown`/`never` to
+ * avoid false positives on untyped code. Finally, we verify the symbol's
+ * declaration lives inside the root `antithrow` entrypoint (excluding the
+ * `antithrow/legacy` subpath) so that unrelated types with the same names
+ * (e.g. a user-defined `Ok` class or the legacy `Ok`) are not flagged.
  */
 export function isResultType(type: ts.Type): boolean {
 	return getResultVariant(type) !== ResultVariant.NONE;

--- a/packages/eslint-plugin/src/rules/utils/test-utils.test.ts
+++ b/packages/eslint-plugin/src/rules/utils/test-utils.test.ts
@@ -3,9 +3,9 @@ import { createCodeHelper } from "./test-utils.js";
 
 describe("createCodeHelper", () => {
 	test("prepends the preamble to static template content", () => {
-		const code = createCodeHelper('import { ok } from "antithrow/legacy";\n');
+		const code = createCodeHelper('import { Ok } from "antithrow";\n');
 
-		expect(code`ok(1);`).toBe('import { ok } from "antithrow/legacy";\nok(1);');
+		expect(code`new Ok(1);`).toBe('import { Ok } from "antithrow";\nnew Ok(1);');
 	});
 
 	test("interpolates values in order and stringifies non-string values", () => {


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [ ] Tests added (if applicable)
- [x] Changeset added (if applicable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate eslint-plugin rules to modern antithrow APIs (Ok, Err, Pending)
> - Updates `no-unsafe-unwrap` and `no-unused-result` rules to recognize `Ok`, `Err`, and `Pending` from the root `antithrow` entrypoint, replacing the legacy `ok`/`err`/`okAsync`/`errAsync`/`ResultAsync` API.
> - Removes `expect` and `expectErr` from the banned method set in `no-unsafe-unwrap`; only `unwrap` and `unwrapErr` are now reported.
> - Updates [`result-type.ts`](https://github.com/antithrow/antithrow/pull/181/files#diff-0eacc91859822a0f73d2d2bad6cdbc7eda41bf11e79fba59c684b5fcc18626c5) to classify unions containing `Pending` as `MIXED`, preventing incorrect OK/ERR-only autofix suggestions.
> - Values imported from `antithrow/legacy` are now ignored by both rules.
> - Behavioral Change: `expect()`/`expectErr()` calls are no longer flagged by `no-unsafe-unwrap`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0792c77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->