### PR TITLE
fix(result): explicitly type sync-or-async callbacks in `Result.try`

### DIFF
--- a/.changeset/fair-rivers-try.md
+++ b/.changeset/fair-rivers-try.md
@@ -1,0 +1,5 @@
+---
+"antithrow": patch
+---
+
+Fix `Result.try` overload typing for callbacks that may return either a sync value or a `PromiseLike`, preserving precise sync and async inference while widening maybe-async callbacks to `Result`.

--- a/.changeset/sharp-timers-clone.md
+++ b/.changeset/sharp-timers-clone.md
@@ -1,0 +1,5 @@
+---
+"@antithrow/std": patch
+---
+
+Fix `structuredClone` by using an explicit synchronous `try`/`catch`, preserving its `Settled` return type even for promise-like values.

--- a/packages/antithrow/src/result.test.ts
+++ b/packages/antithrow/src/result.test.ts
@@ -1128,6 +1128,21 @@ describe("Result", () => {
 			expectTypeOf(result).toEqualTypeOf<Pending<number, string>>();
 		});
 
+		it("returns Result type when callback may return a sync or async value", () => {
+			const syncResult = Result.try<number, string>(() => 42);
+			const asyncResult = Result.try<number, string>(async () => 42);
+			const maybeAsync = (async: boolean): number | PromiseLike<number> =>
+				async ? Promise.resolve(42) : 42;
+
+			const result = Result.try<number, string>(() => maybeAsync(false));
+
+			expect(result.isOk()).toBeTrue();
+			expect(result.unwrap()).toBe(42);
+			expectTypeOf(syncResult).toEqualTypeOf<Settled<number, string>>();
+			expectTypeOf(asyncResult).toEqualTypeOf<Pending<number, string>>();
+			expectTypeOf(result).toEqualTypeOf<Result<number, string>>();
+		});
+
 		it("returns Pending wrapping Err when callback returns a rejected PromiseLike", () => {
 			const result = Result.try<number, string>(async () => {
 				throw "failed";

--- a/packages/antithrow/src/result.ts
+++ b/packages/antithrow/src/result.ts
@@ -1,7 +1,7 @@
 import { Err } from "./err.js";
 import { Ok } from "./ok.js";
 import { Pending } from "./pending.js";
-import type { InferErr, Settled, SyncOrAsync } from "./types.js";
+import type { InferErr, NonThenable, Settled, SyncOrAsync } from "./types.js";
 import { isThenable } from "./utils.js";
 
 /**
@@ -30,7 +30,8 @@ function fromPromise<T, E>(promise: PromiseLike<T>): Pending<T, E> {
 }
 
 function resultTry<T, E>(fn: () => PromiseLike<T>): Pending<T, E>;
-function resultTry<T, E>(fn: () => T): Settled<T, E>;
+function resultTry<T, E>(fn: () => NonThenable<T>): Settled<T, E>;
+function resultTry<T, E>(fn: () => SyncOrAsync<T>): Result<T, E>;
 function resultTry<T, E>(fn: () => SyncOrAsync<T>): Result<T, E> {
 	try {
 		const value = fn();

--- a/packages/std/src/json.ts
+++ b/packages/std/src/json.ts
@@ -87,7 +87,7 @@ export const JSON = {
 		text: string,
 		reviver?: (this: unknown, key: string, value: unknown) => unknown,
 	): Settled<T, SyntaxError> {
-		return Result.try(() => globalThis.JSON.parse(text, reviver) as T);
+		return Result.try(() => globalThis.JSON.parse(text, reviver));
 	},
 
 	stringify,

--- a/packages/std/src/structured-clone.test.ts
+++ b/packages/std/src/structured-clone.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, expectTypeOf, test } from "bun:test";
+import type { Settled } from "antithrow";
 import { structuredClone } from "./structured-clone.js";
 
 describe("structuredClone", () => {
@@ -16,5 +17,14 @@ describe("structuredClone", () => {
 
 		expect(result.isErr()).toBe(true);
 		expect(result.unwrapErr()).toBeInstanceOf(DOMException);
+	});
+
+	test("returns settled Err for Promise values", () => {
+		const result = structuredClone(Promise.resolve(1));
+
+		expect(result.isErr()).toBe(true);
+		expect(result.isPending()).toBe(false);
+		expect(result.unwrapErr()).toBeInstanceOf(DOMException);
+		expectTypeOf(result).toEqualTypeOf<Settled<Promise<number>, DOMException>>();
 	});
 });

--- a/packages/std/src/structured-clone.ts
+++ b/packages/std/src/structured-clone.ts
@@ -1,5 +1,5 @@
 import type { Settled } from "antithrow";
-import { Result } from "antithrow";
+import { Err, Ok } from "antithrow";
 
 /**
  * Non-throwing wrapper around `globalThis.structuredClone(...)`.
@@ -26,5 +26,9 @@ export function structuredClone<T>(
 	value: T,
 	options?: StructuredSerializeOptions,
 ): Settled<T, DOMException> {
-	return Result.try(() => globalThis.structuredClone(value, options));
+	try {
+		return new Ok(globalThis.structuredClone(value, options));
+	} catch (error) {
+		return new Err(error as DOMException);
+	}
 }


### PR DESCRIPTION
## Description

Closes #187 

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Code is formatted (`bun run format`)
- [x] Tests added (if applicable)
- [x] Changeset added (if applicable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Result.try` overload typing to distinguish sync, async, and sync-or-async callbacks
> - Adds a new `Result.try` overload for callbacks returning `SyncOrAsync<T>`, which widens the return type to `Result<T,E>`, while the existing synchronous overload now requires `NonThenable<T>` to preserve the precise `Settled<T,E>` return type.
> - Replaces `Result.try` in the `structuredClone` wrapper with an explicit try/catch so the return type is correctly inferred as `Settled` rather than widened to `Result`.
> - Removes an unnecessary type assertion in the `JSON.parse` wrapper in [json.ts](https://github.com/antithrow/antithrow/pull/188/files#diff-03bbf598121c95440f1be6cdd9e584f45c4a3aa56b39eea434179e2e9d921f9b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a82b663.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->